### PR TITLE
feat: 알림서비스 DB Entity & Repository 구현

### DIFF
--- a/notification-service/README.md
+++ b/notification-service/README.md
@@ -32,9 +32,9 @@ Notification and AI integration service for 14logis logistics system.
 
 ## Database Tables
 
-- `p_notifications`: Message history with sender/recipient snapshots
-- `p_external_api_logs`: External API call monitoring
-- `p_company_delivery_routes`: Daily optimized delivery routes (Challenge)
+- `p_notifications`: Message history with sender/recipient snapshots (20 fields)
+- `p_external_api_logs`: External API call monitoring (13 fields)
+- `p_company_delivery_routes`: Daily optimized delivery routes (Challenge, not implemented)
 
 ## Package Structure (DDD)
 
@@ -73,8 +73,37 @@ EUREKA_SERVER_URL=http://localhost:8761/eureka
 
 ```bash
 # Build image
-docker build -t notification-service:latest ./notification-service
+./gradlew :notification-service:build -x test
+docker-compose build notification-service
 
-# Run container
-docker run -p 8700:8700 notification-service:latest
+# Run with docker-compose
+docker-compose up -d notification-service
+
+# Health check
+curl http://localhost:8700/actuator/health
+# Expected: {"status":"UP"}
+
+# Verify database tables
+docker exec oneforlogis-postgres psql -U root -d oneforlogis_notification -c "\dt"
+# Expected: p_notifications, p_external_api_logs
+
+# Check Eureka registration
+curl http://localhost:8761/eureka/apps/NOTIFICATION-SERVICE
 ```
+
+## Development Status
+
+### ✅ Completed (Issue #12)
+
+- Domain entities: `Notification`, `ExternalApiLog`
+- Repository layer: Domain interfaces + Infrastructure implementations
+- JPA configurations: Auditing, soft delete with `@SQLRestriction`
+- Test coverage: 26 tests (15 Notification + 11 ExternalApiLog) - 100% pass
+- Docker integration: PostgreSQL 17 with JSONB support
+
+### 🚧 Pending
+
+- Presentation layer (REST API controllers)
+- Application layer (Facade, use cases)
+- External API clients (Slack, ChatGPT, Naver Maps)
+- Business logic implementation

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -17,4 +17,8 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
+    testRuntimeOnly 'com.h2database:h2'
 }

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/model/ApiProvider.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/model/ApiProvider.java
@@ -1,0 +1,21 @@
+package com.oneforlogis.notification.domain.model;
+
+/**
+ * 외부 API 제공자
+ */
+public enum ApiProvider {
+    /**
+     * Slack API (chat.postMessage)
+     */
+    SLACK,
+
+    /**
+     * ChatGPT API (출발시간 계산, TSP 경로 최적화)
+     */
+    CHATGPT,
+
+    /**
+     * Naver Maps Directions 5 API (경로 계산)
+     */
+    NAVER_MAPS
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/model/ExternalApiLog.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/model/ExternalApiLog.java
@@ -1,0 +1,153 @@
+package com.oneforlogis.notification.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+// 외부 API 호출 로그 엔티티
+// Slack, ChatGPT, Naver Maps API 호출 이력 추적
+@Entity
+@Table(name = "p_external_api_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExternalApiLog {
+
+    @Id
+    @Column(name = "log_id")
+    private UUID id;
+
+    // API 제공자
+    @Enumerated(EnumType.STRING)
+    @Column(name = "api_provider", nullable = false, length = 20)
+    private ApiProvider apiProvider;
+
+    // API 메서드 (예: chat.postMessage, completions, directions5)
+    @Column(name = "api_method", nullable = false, length = 100)
+    private String apiMethod;
+
+    // 요청 데이터 (JSONB)
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "request_data", columnDefinition = "TEXT")
+    private Map<String, Object> requestData;
+
+    // 응답 데이터 (JSONB)
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "response_data", columnDefinition = "TEXT")
+    private Map<String, Object> responseData;
+
+    // HTTP 상태 코드
+    @Column(name = "http_status")
+    private Integer httpStatus;
+
+    // 성공 여부
+    @Column(name = "is_success", nullable = false)
+    private Boolean isSuccess;
+
+    // 에러 코드
+    @Column(name = "error_code", length = 50)
+    private String errorCode;
+
+    // 에러 메시지
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    private String errorMessage;
+
+    // 응답 시간 (milliseconds)
+    @Column(name = "duration_ms")
+    private Long durationMs;
+
+    // API 호출 비용 (선택적)
+    @Column(name = "cost", precision = 10, scale = 4)
+    private BigDecimal cost;
+
+    // API 호출 시각
+    @Column(name = "called_at", nullable = false)
+    private LocalDateTime calledAt;
+
+    // 연관된 알림 메시지 ID (논리적 FK, nullable)
+    @Column(name = "message_id")
+    private UUID messageId;
+
+    @Builder
+    public ExternalApiLog(
+            ApiProvider apiProvider,
+            String apiMethod,
+            Map<String, Object> requestData,
+            UUID messageId
+    ) {
+        this.id = UUID.randomUUID();
+        this.apiProvider = apiProvider;
+        this.apiMethod = apiMethod;
+        this.requestData = requestData;
+        this.messageId = messageId;
+        this.calledAt = LocalDateTime.now();
+        this.isSuccess = false; // 기본값
+    }
+
+    /**
+     * API 호출 성공 처리
+     */
+    public void recordSuccess(
+            Map<String, Object> responseData,
+            Integer httpStatus,
+            Long durationMs
+    ) {
+        this.isSuccess = true;
+        this.responseData = responseData;
+        this.httpStatus = httpStatus;
+        this.durationMs = durationMs;
+        this.errorCode = null;
+        this.errorMessage = null;
+    }
+
+    /**
+     * API 호출 실패 처리
+     */
+    public void recordFailure(
+            String errorCode,
+            String errorMessage,
+            Integer httpStatus,
+            Long durationMs
+    ) {
+        this.isSuccess = false;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.httpStatus = httpStatus;
+        this.durationMs = durationMs;
+    }
+
+    /**
+     * API 호출 비용 설정
+     */
+    public void setCost(BigDecimal cost) {
+        this.cost = cost;
+    }
+
+    /**
+     * 엔티티 저장 전 검증
+     */
+    @PrePersist
+    @PreUpdate
+    private void validateEntity() {
+        if (apiProvider == null) {
+            throw new IllegalStateException("apiProvider는 필수입니다.");
+        }
+        if (apiMethod == null || apiMethod.isBlank()) {
+            throw new IllegalStateException("apiMethod는 필수입니다.");
+        }
+        if (calledAt == null) {
+            throw new IllegalStateException("calledAt은 필수입니다.");
+        }
+        if (isSuccess == null) {
+            throw new IllegalStateException("isSuccess는 필수입니다.");
+        }
+    }
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/model/MessageStatus.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/model/MessageStatus.java
@@ -1,0 +1,13 @@
+package com.oneforlogis.notification.domain.model;
+
+// 메세지 발송 상태
+public enum MessageStatus {
+    // 발송 대기 상태
+    PENDING,
+
+    // 발송 완료
+    SENT,
+
+    // 발송 실패
+    FAILED
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/model/MessageType.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/model/MessageType.java
@@ -1,0 +1,14 @@
+package com.oneforlogis.notification.domain.model;
+
+// 메시지 타입
+public enum MessageType {
+
+    // 주문 생성 시 알림 (AI 출발시간 계산 포함)
+    ORDER_NOTIFICATION,
+
+    // 일일 경로 최적화 알림 (Challenge 기능, 매일 06:00)
+    DAILY_ROUTE,
+
+    // 사용자가 직접 발송하는 수동 메시지
+    MANUAL
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/model/Notification.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/model/Notification.java
@@ -1,3 +1,159 @@
 package com.oneforlogis.notification.domain.model;
 
-// TODO: Define Notification entity
+import com.oneforlogis.common.model.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// 알림 메시지 엔티티
+// 발신자/수신자 정보를 스냅샷으로 저장하여 감사 추적 보장
+@Entity
+@Table(name = "p_notifications")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+public class Notification extends BaseEntity {
+
+    @Id
+    @Column(name = "message_id")
+    private UUID id;
+
+    // 발신자 타입 (USER: 사용자 발송, SYSTEM: 시스템 자동 발송)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender_type", nullable = false, length = 20)
+    private SenderType senderType;
+
+    // 발신자 사용자명 (USER 타입일 때만 필수)
+    @Column(name = "sender_username", length = 100)
+    private String senderUsername;
+
+    // 발신자 Slack ID (USER 타입일 때만 필수)
+    @Column(name = "sender_slack_id", length = 100)
+    private String senderSlackId;
+
+    // 발신자 이름 (USER 타입일 때만 필수)
+    @Column(name = "sender_name", length = 100)
+    private String senderName;
+
+    // 수신자 Slack ID (필수)
+    @Column(name = "recipient_slack_id", nullable = false, length = 100)
+    private String recipientSlackId;
+
+    // 수신자 이름 (필수)
+    @Column(name = "recipient_name", nullable = false, length = 100)
+    private String recipientName;
+
+    // 메시지 내용
+    @Column(name = "message_content", nullable = false, columnDefinition = "TEXT")
+    private String messageContent;
+
+    // 메시지 타입
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_type", nullable = false, length = 30)
+    private MessageType messageType;
+
+    // 참조 ID (주문 ID, 배송 ID 등)
+    @Column(name = "reference_id")
+    private UUID referenceId;
+
+    // 발송 시각
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    // 발송 상태
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private MessageStatus status;
+
+    // 에러 메시지 (발송 실패 시)
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Builder
+    public Notification(
+            SenderType senderType,
+            String senderUsername,
+            String senderSlackId,
+            String senderName,
+            String recipientSlackId,
+            String recipientName,
+            String messageContent,
+            MessageType messageType,
+            UUID referenceId
+    ) {
+        this.id = UUID.randomUUID();
+        this.senderType = senderType;
+        this.senderUsername = senderUsername;
+        this.senderSlackId = senderSlackId;
+        this.senderName = senderName;
+        this.recipientSlackId = recipientSlackId;
+        this.recipientName = recipientName;
+        this.messageContent = messageContent;
+        this.messageType = messageType;
+        this.referenceId = referenceId;
+        this.status = MessageStatus.PENDING;
+    }
+
+    /**
+     * 메시지 발송 성공 처리
+     */
+    public void markAsSent() {
+        this.status = MessageStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+        this.errorMessage = null;
+    }
+
+    /**
+     * 메시지 발송 실패 처리
+     */
+    public void markAsFailed(String errorMessage) {
+        this.status = MessageStatus.FAILED;
+        this.errorMessage = errorMessage;
+    }
+
+    /**
+     * 엔티티 저장 전 검증
+     */
+    @PrePersist
+    @PreUpdate
+    private void validateEntity() {
+        // USER 타입일 경우 sender 정보 필수
+        if (senderType == SenderType.USER) {
+            if (senderUsername == null || senderUsername.isBlank()) {
+                throw new IllegalStateException("USER 타입 메시지는 senderUsername이 필수입니다.");
+            }
+            if (senderSlackId == null || senderSlackId.isBlank()) {
+                throw new IllegalStateException("USER 타입 메시지는 senderSlackId가 필수입니다.");
+            }
+            if (senderName == null || senderName.isBlank()) {
+                throw new IllegalStateException("USER 타입 메시지는 senderName이 필수입니다.");
+            }
+        }
+
+        // SYSTEM 타입일 경우 sender 정보는 null이어야 함
+        if (senderType == SenderType.SYSTEM) {
+            if (senderUsername != null || senderSlackId != null || senderName != null) {
+                throw new IllegalStateException("SYSTEM 타입 메시지는 sender 정보가 null이어야 합니다.");
+            }
+        }
+
+        // 수신자 정보 필수
+        if (recipientSlackId == null || recipientSlackId.isBlank()) {
+            throw new IllegalStateException("recipientSlackId는 필수입니다.");
+        }
+        if (recipientName == null || recipientName.isBlank()) {
+            throw new IllegalStateException("recipientName은 필수입니다.");
+        }
+
+        // 메시지 내용 필수
+        if (messageContent == null || messageContent.isBlank()) {
+            throw new IllegalStateException("messageContent는 필수입니다.");
+        }
+    }
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/model/SenderType.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/model/SenderType.java
@@ -1,0 +1,10 @@
+package com.oneforlogis.notification.domain.model;
+
+// 발신자 타입
+public enum SenderType {
+    // 사용자가 직접
+    USER,
+
+    // 시스템 자동
+    SYSTEM
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/repository/ExternalApiLogRepository.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/repository/ExternalApiLogRepository.java
@@ -1,0 +1,65 @@
+package com.oneforlogis.notification.domain.repository;
+
+import com.oneforlogis.notification.domain.model.ApiProvider;
+import com.oneforlogis.notification.domain.model.ExternalApiLog;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * ExternalApiLog 도메인 Repository 인터페이스
+ * 인프라스트럭처 레이어에서 구현
+ */
+public interface ExternalApiLogRepository {
+
+    /**
+     * API 로그 저장
+     */
+    ExternalApiLog save(ExternalApiLog log);
+
+    /**
+     * ID로 API 로그 조회
+     */
+    Optional<ExternalApiLog> findById(UUID id);
+
+    /**
+     * 모든 API 로그 조회
+     */
+    List<ExternalApiLog> findAll();
+
+    /**
+     * API 제공자별 로그 조회
+     */
+    List<ExternalApiLog> findByApiProvider(ApiProvider apiProvider);
+
+    /**
+     * 성공 여부로 로그 조회
+     */
+    List<ExternalApiLog> findByIsSuccess(Boolean isSuccess);
+
+    /**
+     * 알림 메시지 ID로 관련 API 로그 조회
+     */
+    List<ExternalApiLog> findByMessageId(UUID messageId);
+
+    /**
+     * 특정 기간 내 API 로그 조회
+     */
+    List<ExternalApiLog> findByCalledAtBetween(LocalDateTime startDate, LocalDateTime endDate);
+
+    /**
+     * API 제공자 및 성공 여부로 로그 조회
+     */
+    List<ExternalApiLog> findByApiProviderAndIsSuccess(ApiProvider apiProvider, Boolean isSuccess);
+
+    /**
+     * 특정 기간 내 API 제공자별 로그 조회
+     */
+    List<ExternalApiLog> findByApiProviderAndCalledAtBetween(
+            ApiProvider apiProvider,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/repository/NotificationRepository.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/repository/NotificationRepository.java
@@ -1,3 +1,66 @@
 package com.oneforlogis.notification.domain.repository;
 
-// TODO: Define repository interfaces
+import com.oneforlogis.notification.domain.model.MessageStatus;
+import com.oneforlogis.notification.domain.model.MessageType;
+import com.oneforlogis.notification.domain.model.Notification;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Notification 도메인 Repository 인터페이스
+ * 인프라스트럭처 레이어에서 구현
+ */
+public interface NotificationRepository {
+
+    /**
+     * 알림 저장
+     */
+    Notification save(Notification notification);
+
+    /**
+     * ID로 알림 조회
+     */
+    Optional<Notification> findById(UUID id);
+
+    /**
+     * 모든 알림 조회 (Soft Delete 제외)
+     */
+    List<Notification> findAll();
+
+    /**
+     * 상태별 알림 조회
+     */
+    List<Notification> findByStatus(MessageStatus status);
+
+    /**
+     * 메시지 타입별 알림 조회
+     */
+    List<Notification> findByMessageType(MessageType messageType);
+
+    /**
+     * 수신자 Slack ID로 알림 조회
+     */
+    List<Notification> findByRecipientSlackId(String recipientSlackId);
+
+    /**
+     * 참조 ID로 알림 조회 (주문 ID, 배송 ID 등)
+     */
+    List<Notification> findByReferenceId(UUID referenceId);
+
+    /**
+     * 발신자 사용자명으로 알림 조회
+     */
+    List<Notification> findBySenderUsername(String senderUsername);
+
+    /**
+     * 알림 삭제 (Soft Delete)
+     */
+    void delete(Notification notification);
+
+    /**
+     * ID로 알림 삭제 (Soft Delete)
+     */
+    void deleteById(UUID id);
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/ExternalApiLogJpaRepository.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/ExternalApiLogJpaRepository.java
@@ -1,0 +1,50 @@
+package com.oneforlogis.notification.infrastructure.persistence;
+
+import com.oneforlogis.notification.domain.model.ApiProvider;
+import com.oneforlogis.notification.domain.model.ExternalApiLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * ExternalApiLog JPA Repository
+ * Spring Data JPA가 자동으로 구현체 생성
+ */
+public interface ExternalApiLogJpaRepository extends JpaRepository<ExternalApiLog, UUID> {
+
+    /**
+     * API 제공자별 로그 조회
+     */
+    List<ExternalApiLog> findByApiProvider(ApiProvider apiProvider);
+
+    /**
+     * 성공 여부로 로그 조회
+     */
+    List<ExternalApiLog> findByIsSuccess(Boolean isSuccess);
+
+    /**
+     * 알림 메시지 ID로 관련 API 로그 조회
+     */
+    List<ExternalApiLog> findByMessageId(UUID messageId);
+
+    /**
+     * 특정 기간 내 API 로그 조회
+     */
+    List<ExternalApiLog> findByCalledAtBetween(LocalDateTime startDate, LocalDateTime endDate);
+
+    /**
+     * API 제공자 및 성공 여부로 로그 조회
+     */
+    List<ExternalApiLog> findByApiProviderAndIsSuccess(ApiProvider apiProvider, Boolean isSuccess);
+
+    /**
+     * 특정 기간 내 API 제공자별 로그 조회
+     */
+    List<ExternalApiLog> findByApiProviderAndCalledAtBetween(
+            ApiProvider apiProvider,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/ExternalApiLogRepositoryImpl.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/ExternalApiLogRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.oneforlogis.notification.infrastructure.persistence;
+
+import com.oneforlogis.notification.domain.model.ApiProvider;
+import com.oneforlogis.notification.domain.model.ExternalApiLog;
+import com.oneforlogis.notification.domain.repository.ExternalApiLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+// ExternalApiLogRepository 구현체
+// JPA Repository를 래핑하여 도메인 레이어의 인터페이스 구현
+@Repository
+@RequiredArgsConstructor
+public class ExternalApiLogRepositoryImpl implements ExternalApiLogRepository {
+
+    private final ExternalApiLogJpaRepository jpaRepository;
+
+    @Override
+    public ExternalApiLog save(ExternalApiLog log) {
+        return jpaRepository.save(log);
+    }
+
+    @Override
+    public Optional<ExternalApiLog> findById(UUID id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<ExternalApiLog> findAll() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public List<ExternalApiLog> findByApiProvider(ApiProvider apiProvider) {
+        return jpaRepository.findByApiProvider(apiProvider);
+    }
+
+    @Override
+    public List<ExternalApiLog> findByIsSuccess(Boolean isSuccess) {
+        return jpaRepository.findByIsSuccess(isSuccess);
+    }
+
+    @Override
+    public List<ExternalApiLog> findByMessageId(UUID messageId) {
+        return jpaRepository.findByMessageId(messageId);
+    }
+
+    @Override
+    public List<ExternalApiLog> findByCalledAtBetween(LocalDateTime startDate, LocalDateTime endDate) {
+        return jpaRepository.findByCalledAtBetween(startDate, endDate);
+    }
+
+    @Override
+    public List<ExternalApiLog> findByApiProviderAndIsSuccess(ApiProvider apiProvider, Boolean isSuccess) {
+        return jpaRepository.findByApiProviderAndIsSuccess(apiProvider, isSuccess);
+    }
+
+    @Override
+    public List<ExternalApiLog> findByApiProviderAndCalledAtBetween(
+            ApiProvider apiProvider,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    ) {
+        return jpaRepository.findByApiProviderAndCalledAtBetween(apiProvider, startDate, endDate);
+    }
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/NotificationJpaRepository.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/NotificationJpaRepository.java
@@ -1,3 +1,41 @@
 package com.oneforlogis.notification.infrastructure.persistence;
 
-// TODO: Define JPA repositories
+import com.oneforlogis.notification.domain.model.MessageStatus;
+import com.oneforlogis.notification.domain.model.MessageType;
+import com.oneforlogis.notification.domain.model.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Notification JPA Repository
+ * Spring Data JPA가 자동으로 구현체 생성
+ */
+public interface NotificationJpaRepository extends JpaRepository<Notification, UUID> {
+
+    /**
+     * 상태별 알림 조회
+     */
+    List<Notification> findByStatus(MessageStatus status);
+
+    /**
+     * 메시지 타입별 알림 조회
+     */
+    List<Notification> findByMessageType(MessageType messageType);
+
+    /**
+     * 수신자 Slack ID로 알림 조회
+     */
+    List<Notification> findByRecipientSlackId(String recipientSlackId);
+
+    /**
+     * 참조 ID로 알림 조회
+     */
+    List<Notification> findByReferenceId(UUID referenceId);
+
+    /**
+     * 발신자 사용자명으로 알림 조회
+     */
+    List<Notification> findBySenderUsername(String senderUsername);
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/NotificationRepositoryImpl.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/NotificationRepositoryImpl.java
@@ -1,0 +1,75 @@
+package com.oneforlogis.notification.infrastructure.persistence;
+
+import com.oneforlogis.notification.domain.model.MessageStatus;
+import com.oneforlogis.notification.domain.model.MessageType;
+import com.oneforlogis.notification.domain.model.Notification;
+import com.oneforlogis.notification.domain.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+// NotificationRepository 구현체
+// JPA Repository를 래핑하여 도메인 레이어의 인터페이스 구현
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepository {
+
+    private final NotificationJpaRepository jpaRepository;
+
+    @Override
+    public Notification save(Notification notification) {
+        return jpaRepository.save(notification);
+    }
+
+    @Override
+    public Optional<Notification> findById(UUID id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Notification> findAll() {
+        return jpaRepository.findAll();
+    }
+
+    @Override
+    public List<Notification> findByStatus(MessageStatus status) {
+        return jpaRepository.findByStatus(status);
+    }
+
+    @Override
+    public List<Notification> findByMessageType(MessageType messageType) {
+        return jpaRepository.findByMessageType(messageType);
+    }
+
+    @Override
+    public List<Notification> findByRecipientSlackId(String recipientSlackId) {
+        return jpaRepository.findByRecipientSlackId(recipientSlackId);
+    }
+
+    @Override
+    public List<Notification> findByReferenceId(UUID referenceId) {
+        return jpaRepository.findByReferenceId(referenceId);
+    }
+
+    @Override
+    public List<Notification> findBySenderUsername(String senderUsername) {
+        return jpaRepository.findBySenderUsername(senderUsername);
+    }
+
+    @Override
+    public void delete(Notification notification) {
+        notification.markAsDeleted("SYSTEM"); // TODO: 실제 사용자 정보로 변경
+        jpaRepository.save(notification);
+    }
+
+    @Override
+    public void deleteById(UUID id) {
+        jpaRepository.findById(id).ifPresent(notification -> {
+            notification.markAsDeleted("SYSTEM"); // TODO: 실제 사용자 정보로 변경
+            jpaRepository.save(notification);
+        });
+    }
+}

--- a/notification-service/src/test/java/com/oneforlogis/notification/config/TestJpaConfig.java
+++ b/notification-service/src/test/java/com/oneforlogis/notification/config/TestJpaConfig.java
@@ -1,0 +1,19 @@
+package com.oneforlogis.notification.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+
+// 테스트용 JPA Auditing 설정
+@TestConfiguration
+@EnableJpaAuditing
+public class TestJpaConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> Optional.of("TEST_USER");
+    }
+}

--- a/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/persistence/ExternalApiLogRepositoryTest.java
+++ b/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/persistence/ExternalApiLogRepositoryTest.java
@@ -1,0 +1,288 @@
+package com.oneforlogis.notification.infrastructure.persistence;
+
+import com.oneforlogis.notification.domain.model.ApiProvider;
+import com.oneforlogis.notification.domain.model.ExternalApiLog;
+import com.oneforlogis.notification.domain.repository.ExternalApiLogRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+// ExternalApiLogRepository 통합 테스트
+@DataJpaTest
+@Import({ExternalApiLogRepositoryImpl.class, com.oneforlogis.notification.config.TestJpaConfig.class})
+@ActiveProfiles("test")
+class ExternalApiLogRepositoryTest {
+
+    @Autowired
+    private ExternalApiLogRepository externalApiLogRepository;
+
+    @Autowired
+    private jakarta.persistence.EntityManager entityManager;
+
+    @Test
+    @DisplayName("API 로그 저장 및 조회 테스트")
+    void saveAndFindApiLog() {
+        // Given
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put("channel", "C12345");
+        requestData.put("text", "테스트 메시지");
+
+        ExternalApiLog log = ExternalApiLog.builder()
+                .apiProvider(ApiProvider.SLACK)
+                .apiMethod("chat.postMessage")
+                .requestData(requestData)
+                .messageId(UUID.randomUUID())
+                .build();
+
+        // When
+        ExternalApiLog saved = externalApiLogRepository.save(log);
+        Optional<ExternalApiLog> found = externalApiLogRepository.findById(saved.getId());
+
+        // Then
+        assertThat(found).isPresent();
+        assertThat(found.get().getApiProvider()).isEqualTo(ApiProvider.SLACK);
+        assertThat(found.get().getApiMethod()).isEqualTo("chat.postMessage");
+        assertThat(found.get().getIsSuccess()).isFalse(); // 기본값
+    }
+
+    @Test
+    @DisplayName("API 호출 성공 기록 테스트")
+    void recordApiSuccess() {
+        // Given
+        ExternalApiLog log = createApiLog(ApiProvider.CHATGPT, "completions");
+        ExternalApiLog saved = externalApiLogRepository.save(log);
+
+        // When
+        Map<String, Object> responseData = new HashMap<>();
+        responseData.put("choices", List.of("응답 내용"));
+        saved.recordSuccess(responseData, 200, 1500L);
+        externalApiLogRepository.save(saved);
+
+        // Then
+        Optional<ExternalApiLog> found = externalApiLogRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getIsSuccess()).isTrue();
+        assertThat(found.get().getHttpStatus()).isEqualTo(200);
+        assertThat(found.get().getDurationMs()).isEqualTo(1500L);
+        assertThat(found.get().getResponseData()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("API 호출 실패 기록 테스트")
+    void recordApiFailure() {
+        // Given
+        ExternalApiLog log = createApiLog(ApiProvider.SLACK, "chat.postMessage");
+        ExternalApiLog saved = externalApiLogRepository.save(log);
+
+        // When
+        saved.recordFailure("RATE_LIMITED", "Too many requests", 429, 500L);
+        externalApiLogRepository.save(saved);
+
+        // Then
+        Optional<ExternalApiLog> found = externalApiLogRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getIsSuccess()).isFalse();
+        assertThat(found.get().getErrorCode()).isEqualTo("RATE_LIMITED");
+        assertThat(found.get().getErrorMessage()).isEqualTo("Too many requests");
+        assertThat(found.get().getHttpStatus()).isEqualTo(429);
+    }
+
+    @Test
+    @DisplayName("API 제공자별 로그 조회 테스트")
+    void findByApiProvider() {
+        // Given
+        ExternalApiLog slackLog = createApiLog(ApiProvider.SLACK, "chat.postMessage");
+        ExternalApiLog chatGptLog = createApiLog(ApiProvider.CHATGPT, "completions");
+        externalApiLogRepository.save(slackLog);
+        externalApiLogRepository.save(chatGptLog);
+
+        // When
+        List<ExternalApiLog> slackLogs = externalApiLogRepository.findByApiProvider(ApiProvider.SLACK);
+
+        // Then
+        assertThat(slackLogs).isNotEmpty();
+        assertThat(slackLogs).allMatch(log -> log.getApiProvider() == ApiProvider.SLACK);
+    }
+
+    @Test
+    @DisplayName("성공 여부로 로그 조회 테스트")
+    void findByIsSuccess() {
+        // Given
+        ExternalApiLog successLog = createApiLog(ApiProvider.SLACK, "chat.postMessage");
+        successLog.recordSuccess(Map.of("ok", true), 200, 1000L);
+
+        ExternalApiLog failLog = createApiLog(ApiProvider.CHATGPT, "completions");
+        failLog.recordFailure("ERROR", "Failed", 500, 2000L);
+
+        externalApiLogRepository.save(successLog);
+        externalApiLogRepository.save(failLog);
+
+        // When
+        List<ExternalApiLog> successLogs = externalApiLogRepository.findByIsSuccess(true);
+        List<ExternalApiLog> failLogs = externalApiLogRepository.findByIsSuccess(false);
+
+        // Then
+        assertThat(successLogs).isNotEmpty();
+        assertThat(failLogs).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("메시지 ID로 관련 API 로그 조회 테스트")
+    void findByMessageId() {
+        // Given
+        UUID messageId = UUID.randomUUID();
+        ExternalApiLog log1 = createApiLogWithMessageId(ApiProvider.SLACK, messageId);
+        ExternalApiLog log2 = createApiLogWithMessageId(ApiProvider.CHATGPT, messageId);
+        externalApiLogRepository.save(log1);
+        externalApiLogRepository.save(log2);
+
+        // When
+        List<ExternalApiLog> logs = externalApiLogRepository.findByMessageId(messageId);
+
+        // Then
+        assertThat(logs).hasSize(2);
+        assertThat(logs).allMatch(log -> log.getMessageId().equals(messageId));
+    }
+
+    @Test
+    @DisplayName("특정 기간 내 API 로그 조회 테스트")
+    void findByCalledAtBetween() {
+        // Given
+        LocalDateTime start = LocalDateTime.now().minusHours(1);
+        LocalDateTime end = LocalDateTime.now().plusHours(1);
+
+        ExternalApiLog log = createApiLog(ApiProvider.NAVER_MAPS, "directions5");
+        externalApiLogRepository.save(log);
+
+        // When
+        List<ExternalApiLog> logs = externalApiLogRepository.findByCalledAtBetween(start, end);
+
+        // Then
+        assertThat(logs).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("API 제공자 및 성공 여부로 로그 조회 테스트")
+    void findByApiProviderAndIsSuccess() {
+        // Given
+        ExternalApiLog successLog = createApiLog(ApiProvider.SLACK, "chat.postMessage");
+        successLog.recordSuccess(Map.of(), 200, 1000L);
+        externalApiLogRepository.save(successLog);
+
+        // When
+        List<ExternalApiLog> logs = externalApiLogRepository.findByApiProviderAndIsSuccess(
+                ApiProvider.SLACK, true
+        );
+
+        // Then
+        assertThat(logs).isNotEmpty();
+        assertThat(logs).allMatch(log ->
+                log.getApiProvider() == ApiProvider.SLACK && log.getIsSuccess()
+        );
+    }
+
+    @Test
+    @DisplayName("특정 기간 내 API 제공자별 로그 조회 테스트")
+    void findByApiProviderAndCalledAtBetween() {
+        // Given
+        LocalDateTime start = LocalDateTime.now().minusHours(1);
+        LocalDateTime end = LocalDateTime.now().plusHours(1);
+
+        ExternalApiLog log = createApiLog(ApiProvider.CHATGPT, "completions");
+        externalApiLogRepository.save(log);
+
+        // When
+        List<ExternalApiLog> logs = externalApiLogRepository.findByApiProviderAndCalledAtBetween(
+                ApiProvider.CHATGPT, start, end
+        );
+
+        // Then
+        assertThat(logs).isNotEmpty();
+        assertThat(logs).allMatch(l -> l.getApiProvider() == ApiProvider.CHATGPT);
+    }
+
+    @Test
+    @DisplayName("API 호출 비용 설정 테스트")
+    void setApiCost() {
+        // Given
+        ExternalApiLog log = createApiLog(ApiProvider.CHATGPT, "completions");
+        ExternalApiLog saved = externalApiLogRepository.save(log);
+
+        // When
+        BigDecimal cost = new BigDecimal("0.0025");
+        saved.setCost(cost);
+        externalApiLogRepository.save(saved);
+
+        // Then
+        Optional<ExternalApiLog> found = externalApiLogRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getCost()).isEqualByComparingTo(cost);
+    }
+
+    @Test
+    @DisplayName("JSONB 필드 저장 및 조회 테스트")
+    void saveAndRetrieveJsonbData() {
+        // Given
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put("model", "gpt-4");
+        requestData.put("messages", List.of(
+                Map.of("role", "user", "content", "테스트 질문")
+        ));
+
+        Map<String, Object> responseData = new HashMap<>();
+        responseData.put("choices", List.of(
+                Map.of("message", Map.of("content", "테스트 응답"))
+        ));
+
+        ExternalApiLog log = ExternalApiLog.builder()
+                .apiProvider(ApiProvider.CHATGPT)
+                .apiMethod("completions")
+                .requestData(requestData)
+                .build();
+
+        log.recordSuccess(responseData, 200, 2000L);
+
+        // When
+        ExternalApiLog saved = externalApiLogRepository.save(log);
+
+        // Then
+        Optional<ExternalApiLog> found = externalApiLogRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getRequestData()).containsKey("model");
+        assertThat(found.get().getResponseData()).containsKey("choices");
+    }
+
+    // Helper methods
+    private ExternalApiLog createApiLog(ApiProvider provider, String method) {
+        Map<String, Object> requestData = new HashMap<>();
+        requestData.put("test", "data");
+
+        return ExternalApiLog.builder()
+                .apiProvider(provider)
+                .apiMethod(method)
+                .requestData(requestData)
+                .build();
+    }
+
+    private ExternalApiLog createApiLogWithMessageId(ApiProvider provider, UUID messageId) {
+        return ExternalApiLog.builder()
+                .apiProvider(provider)
+                .apiMethod("test.method")
+                .requestData(Map.of("test", "data"))
+                .messageId(messageId)
+                .build();
+    }
+}

--- a/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/persistence/NotificationRepositoryTest.java
+++ b/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/persistence/NotificationRepositoryTest.java
@@ -1,0 +1,378 @@
+package com.oneforlogis.notification.infrastructure.persistence;
+
+import com.oneforlogis.notification.domain.model.*;
+import com.oneforlogis.notification.domain.repository.NotificationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+
+// NotificationRepository 통합 테스트
+// @DataJpaTest: JPA 관련 컴포넌트만 로드 (in-memory H2 사용)
+@DataJpaTest
+@Import({NotificationRepositoryImpl.class, com.oneforlogis.notification.config.TestJpaConfig.class})
+@ActiveProfiles("test")
+class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private jakarta.persistence.EntityManager entityManager;
+
+    @Test
+    @DisplayName("USER 타입 알림 저장 및 조회 테스트")
+    void saveAndFindUserNotification() {
+        // Given
+        Notification notification = Notification.builder()
+                .senderType(SenderType.USER)
+                .senderUsername("testuser")
+                .senderSlackId("U12345")
+                .senderName("테스트 사용자")
+                .recipientSlackId("U67890")
+                .recipientName("수신자")
+                .messageContent("테스트 메시지입니다.")
+                .messageType(MessageType.MANUAL)
+                .referenceId(UUID.randomUUID())
+                .build();
+
+        // When
+        Notification saved = notificationRepository.save(notification);
+        Optional<Notification> found = notificationRepository.findById(saved.getId());
+
+        // Then
+        assertThat(found).isPresent();
+        assertThat(found.get().getSenderType()).isEqualTo(SenderType.USER);
+        assertThat(found.get().getSenderUsername()).isEqualTo("testuser");
+        assertThat(found.get().getStatus()).isEqualTo(MessageStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("SYSTEM 타입 알림 저장 테스트")
+    void saveSystemNotification() {
+        // Given
+        Notification notification = Notification.builder()
+                .senderType(SenderType.SYSTEM)
+                .senderUsername(null) // SYSTEM은 sender 정보 null
+                .senderSlackId(null)
+                .senderName(null)
+                .recipientSlackId("U67890")
+                .recipientName("수신자")
+                .messageContent("시스템 자동 알림입니다.")
+                .messageType(MessageType.ORDER_NOTIFICATION)
+                .referenceId(UUID.randomUUID())
+                .build();
+
+        // When
+        Notification saved = notificationRepository.save(notification);
+        Optional<Notification> found = notificationRepository.findById(saved.getId());
+
+        // Then
+        assertThat(found).isPresent();
+        assertThat(found.get().getSenderType()).isEqualTo(SenderType.SYSTEM);
+        assertThat(found.get().getSenderUsername()).isNull();
+    }
+
+    @Test
+    @DisplayName("상태별 알림 조회 테스트")
+    void findByStatus() {
+        // Given
+        Notification notification1 = createNotification(MessageStatus.PENDING);
+        Notification notification2 = createNotification(MessageStatus.PENDING);
+        notificationRepository.save(notification1);
+        notificationRepository.save(notification2);
+
+        // When
+        List<Notification> pendingList = notificationRepository.findByStatus(MessageStatus.PENDING);
+
+        // Then
+        assertThat(pendingList).hasSizeGreaterThanOrEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("메시지 타입별 알림 조회 테스트")
+    void findByMessageType() {
+        // Given
+        Notification notification = Notification.builder()
+                .senderType(SenderType.SYSTEM)
+                .recipientSlackId("U67890")
+                .recipientName("수신자")
+                .messageContent("주문 알림")
+                .messageType(MessageType.ORDER_NOTIFICATION)
+                .build();
+        notificationRepository.save(notification);
+
+        // When
+        List<Notification> orderNotifications = notificationRepository.findByMessageType(MessageType.ORDER_NOTIFICATION);
+
+        // Then
+        assertThat(orderNotifications).isNotEmpty();
+        assertThat(orderNotifications.get(0).getMessageType()).isEqualTo(MessageType.ORDER_NOTIFICATION);
+    }
+
+    @Test
+    @DisplayName("수신자 Slack ID로 알림 조회 테스트")
+    void findByRecipientSlackId() {
+        // Given
+        String recipientSlackId = "U99999";
+        Notification notification = Notification.builder()
+                .senderType(SenderType.SYSTEM)
+                .recipientSlackId(recipientSlackId)
+                .recipientName("특정 수신자")
+                .messageContent("테스트")
+                .messageType(MessageType.MANUAL)
+                .build();
+        notificationRepository.save(notification);
+
+        // When
+        List<Notification> result = notificationRepository.findByRecipientSlackId(recipientSlackId);
+
+        // Then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).getRecipientSlackId()).isEqualTo(recipientSlackId);
+    }
+
+    @Test
+    @DisplayName("참조 ID로 알림 조회 테스트")
+    void findByReferenceId() {
+        // Given
+        UUID referenceId = UUID.randomUUID();
+        Notification notification = Notification.builder()
+                .senderType(SenderType.SYSTEM)
+                .recipientSlackId("U12345")
+                .recipientName("수신자")
+                .messageContent("주문 관련 알림")
+                .messageType(MessageType.ORDER_NOTIFICATION)
+                .referenceId(referenceId)
+                .build();
+        notificationRepository.save(notification);
+
+        // When
+        List<Notification> result = notificationRepository.findByReferenceId(referenceId);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getReferenceId()).isEqualTo(referenceId);
+    }
+
+    @Test
+    @DisplayName("발신자 사용자명으로 알림 조회 테스트")
+    void findBySenderUsername() {
+        // Given
+        String username = "sender123";
+        Notification notification = Notification.builder()
+                .senderType(SenderType.USER)
+                .senderUsername(username)
+                .senderSlackId("U11111")
+                .senderName("발신자")
+                .recipientSlackId("U22222")
+                .recipientName("수신자")
+                .messageContent("테스트 메시지")
+                .messageType(MessageType.MANUAL)
+                .build();
+        notificationRepository.save(notification);
+
+        // When
+        List<Notification> result = notificationRepository.findBySenderUsername(username);
+
+        // Then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).getSenderUsername()).isEqualTo(username);
+    }
+
+    @Test
+    @DisplayName("알림 발송 성공 처리 테스트")
+    void markNotificationAsSent() {
+        // Given
+        Notification notification = createNotification(MessageStatus.PENDING);
+        Notification saved = notificationRepository.save(notification);
+
+        // When
+        saved.markAsSent();
+        notificationRepository.save(saved);
+
+        // Then
+        Optional<Notification> found = notificationRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getStatus()).isEqualTo(MessageStatus.SENT);
+        assertThat(found.get().getSentAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("알림 발송 실패 처리 테스트")
+    void markNotificationAsFailed() {
+        // Given
+        Notification notification = createNotification(MessageStatus.PENDING);
+        Notification saved = notificationRepository.save(notification);
+
+        // When
+        String errorMessage = "Slack API 호출 실패";
+        saved.markAsFailed(errorMessage);
+        notificationRepository.save(saved);
+
+        // Then
+        Optional<Notification> found = notificationRepository.findById(saved.getId());
+        assertThat(found).isPresent();
+        assertThat(found.get().getStatus()).isEqualTo(MessageStatus.FAILED);
+        assertThat(found.get().getErrorMessage()).isEqualTo(errorMessage);
+    }
+
+    @Test
+    @DisplayName("Soft Delete 후 BaseEntity의 deletedAt 필드 확인")
+    void softDeleteSetsDeletedAtField() {
+        // Given
+        Notification notification = createNotification(MessageStatus.PENDING);
+        Notification saved = notificationRepository.save(notification);
+        UUID id = saved.getId();
+
+        // When
+        notificationRepository.deleteById(id);
+        entityManager.flush();
+        entityManager.clear(); // 영속성 컨텍스트 초기화
+
+        // Then - 네이티브 쿼리로 직접 확인 (H2에서도 동작)
+        Object result = entityManager.createNativeQuery(
+                "SELECT deleted_at FROM p_notifications WHERE message_id = ?")
+                .setParameter(1, id)
+                .getSingleResult();
+
+        assertThat(result).isNotNull(); // deleted_at이 설정됨
+    }
+
+    @Test
+    @DisplayName("Soft Delete 후 일반 조회에서 제외 확인")
+    void softDeletedNotificationIsNotFoundByNormalQuery() {
+        // Given
+        Notification notification1 = createNotification(MessageStatus.PENDING);
+        Notification notification2 = createNotification(MessageStatus.PENDING);
+        notificationRepository.save(notification1);
+        Notification saved2 = notificationRepository.save(notification2);
+
+        int beforeCount = notificationRepository.findAll().size();
+
+        // When - notification2만 삭제
+        notificationRepository.deleteById(saved2.getId());
+        entityManager.flush();
+        entityManager.clear();
+
+        // Then - findAll 결과에서 제외됨
+        List<Notification> afterList = notificationRepository.findAll();
+        assertThat(afterList.size()).isEqualTo(beforeCount - 1);
+        assertThat(afterList).noneMatch(n -> n.getId().equals(saved2.getId()));
+    }
+
+    @Test
+    @DisplayName("USER 타입에서 sender 정보 없으면 저장 실패")
+    void userTypeWithoutSenderInfoValidation() {
+        // Given - USER 타입인데 senderUsername만 null
+        Notification notification = Notification.builder()
+                .senderType(SenderType.USER)
+                .senderUsername(null)
+                .senderSlackId("U12345")
+                .senderName("테스트")
+                .recipientSlackId("U67890")
+                .recipientName("수신자")
+                .messageContent("테스트")
+                .messageType(MessageType.MANUAL)
+                .build();
+
+        // When & Then - 저장 시도 시 예외 발생
+        assertThatThrownBy(() -> {
+            notificationRepository.save(notification);
+            entityManager.flush();
+        }).isInstanceOf(Exception.class); // IllegalStateException 또는 PersistenceException
+    }
+
+    @Test
+    @DisplayName("USER 타입에서 senderSlackId 없으면 저장 실패")
+    void userTypeWithoutSenderSlackIdValidation() {
+        // Given - USER 타입인데 senderSlackId가 null
+        Notification notification = Notification.builder()
+                .senderType(SenderType.USER)
+                .senderUsername("testuser")
+                .senderSlackId(null)
+                .senderName("테스트")
+                .recipientSlackId("U67890")
+                .recipientName("수신자")
+                .messageContent("테스트")
+                .messageType(MessageType.MANUAL)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> {
+            notificationRepository.save(notification);
+            entityManager.flush();
+        }).isInstanceOf(Exception.class);
+    }
+
+    @Test
+    @DisplayName("USER 타입에서 senderName 없으면 저장 실패")
+    void userTypeWithoutSenderNameValidation() {
+        // Given - USER 타입인데 senderName이 null
+        Notification notification = Notification.builder()
+                .senderType(SenderType.USER)
+                .senderUsername("testuser")
+                .senderSlackId("U12345")
+                .senderName(null)
+                .recipientSlackId("U67890")
+                .recipientName("수신자")
+                .messageContent("테스트")
+                .messageType(MessageType.MANUAL)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> {
+            notificationRepository.save(notification);
+            entityManager.flush();
+        }).isInstanceOf(Exception.class);
+    }
+
+    @Test
+    @DisplayName("SYSTEM 타입에서 sender 정보 있으면 저장 실패")
+    void systemTypeWithSenderInfoValidation() {
+        // Given - SYSTEM 타입인데 senderUsername이 있음
+        Notification notification = Notification.builder()
+                .senderType(SenderType.SYSTEM)
+                .senderUsername("testuser")
+                .senderSlackId(null)
+                .senderName(null)
+                .recipientSlackId("U67890")
+                .recipientName("수신자")
+                .messageContent("테스트")
+                .messageType(MessageType.ORDER_NOTIFICATION)
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> {
+            notificationRepository.save(notification);
+            entityManager.flush();
+        }).isInstanceOf(Exception.class);
+    }
+
+    // Helper method
+    private Notification createNotification(MessageStatus status) {
+        Notification notification = Notification.builder()
+                .senderType(SenderType.SYSTEM)
+                .recipientSlackId("U12345")
+                .recipientName("테스트 수신자")
+                .messageContent("테스트 메시지")
+                .messageType(MessageType.MANUAL)
+                .build();
+
+        if (status == MessageStatus.SENT) {
+            notification.markAsSent();
+        } else if (status == MessageStatus.FAILED) {
+            notification.markAsFailed("테스트 에러");
+        }
+
+        return notification;
+    }
+}

--- a/notification-service/src/test/resources/application-test.yml
+++ b/notification-service/src/test/resources/application-test.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        show_sql: true
+
+  h2:
+    console:
+      enabled: true


### PR DESCRIPTION
  ## Issue Number
  > closed #12

  ## 📝 Description

  notification-service의 DB Entity 및 Repository 레이어를 구현했습니다.

  ### 주요 구현 내용

  **1. Domain Entity 생성**
  - `Notification`: 알림 메시지 엔티티 (20개 필드)
    - Snapshot 패턴: 발신자 정보를 메시지 발송 시점에 저장하여 감사 추적 보장
    - SenderType: USER/SYSTEM 구분, USER 타입은 발신자 정보 필수 검증
    - MessageStatus: PENDING/SENT/FAILED 상태 관리
    - Soft delete 지원 (`@SQLRestriction`)

  - `ExternalApiLog`: 외부 API 호출 로그 엔티티 (13개 필드)
    - API Provider: SLACK, CHATGPT, NAVER_MAPS 지원
    - JSONB 필드: request_data, response_data (PostgreSQL JSONB, H2 TEXT)
    - 성공/실패 기록, 응답 시간, 비용 추적

  **2. Repository 레이어 구현**
  - Domain layer: Repository 인터페이스 (도메인 독립성 유지)
  - Infrastructure layer: JPA Repository 구현체
  - 총 8개 쿼리 메서드 (Notification), 7개 쿼리 메서드 (ExternalApiLog)

  **3. Test 구현**
  - 통합 테스트 26개 (100% pass)
    - NotificationRepositoryTest: 15개 테스트
    - ExternalApiLogRepositoryTest: 11개 테스트
  - H2 호환성 확보 (JSONB → TEXT columnDefinition)
  - Soft delete 검증 (native query 사용)
  - JPA Auditing 검증 (`@PrePersist` validation)

  **4. 설정 파일**
  - `JpaAuditingConfig`: Auditing 활성화
  - `TestJpaConfig`: 테스트용 Auditor 설정

  **5. Docker 통합**
  - PostgreSQL 17 연동 확인
  - 테이블 자동 생성 검증 (p_notifications, p_external_api_logs)
  - Eureka 등록 확인

  ### 기술적 의사결정

  1. **JSONB → TEXT columnDefinition**: H2 테스트 환경 호환성을 위해 추가 (PostgreSQL에서는 Hibernate가 JSONB로 매핑)
  2. **Snapshot 패턴**: 발신자 정보 변경/삭제 시에도 알림 이력 보존
  3. **Validation in Entity**: `@PrePersist`에서 SenderType별 필수 필드 검증
  4. **Soft Delete**: `@SQLRestriction("deleted_at IS NULL")`로 모든 쿼리에 자동 필터 적용

  ### 파일 변경 사항

  **신규 생성 (14개)**:
  - Domain: Notification.java, ExternalApiLog.java, 4 Enums, 2 Repository interfaces
  - Infrastructure: 2 RepositoryImpl, 2 JpaRepository interfaces
  - Config: JpaAuditingConfig.java, TestJpaConfig.java
  - Test: 2 Test classes

  **문서**:
  - README.md 업데이트 (Docker 검증 방법, 개발 상태 추가)

  ## 🌐 Test Result

  ### 테스트 실행 결과
  ```bash
  ./gradlew :notification-service:test

  BUILD SUCCESSFUL
  26 tests completed, 26 passed

  Docker 환경 검증

  # 컨테이너 상태
  docker ps
  # oneforlogis-notification-service: Up
  # oneforlogis-postgres: Up (healthy)

  # Health check
  curl http://localhost:8700/actuator/health
  # {"status":"UP"}

  # 데이터베이스 테이블 확인
  docker exec oneforlogis-postgres psql -U root -d oneforlogis_notification -c "\dt"
  # p_notifications (20 columns)
  # p_external_api_logs (13 columns)

  # Eureka 등록 확인
  curl http://localhost:8761/eureka/apps/NOTIFICATION-SERVICE
  # Status: UP
```
  🔎 To Reviewer

  리뷰 포인트

  1. Snapshot 패턴 구현 확인
    - Notification 엔티티에서 발신자 정보를 메시지 발송 시점에 저장하는 방식이 적절한지 확인 부탁드립니다.
    - SenderType.USER일 때만 sender 필드들이 필수인 조건부 검증 로직 (@PrePersist)
  2. JSONB 필드 처리
    - PostgreSQL JSONB와 H2 TEXT 호환을 위한 columnDefinition="TEXT" 방식이 적절한지 확인 부탁드립니다.
    - @JdbcTypeCode(SqlTypes.JSON) 사용으로 Hibernate가 자동 매핑
  3. Soft Delete 구현
    - @SQLRestriction("deleted_at IS NULL") 사용 방식
    - Repository에서 soft delete 처리 로직 (markAsDeleted() 호출)
  4. Test 커버리지
    - H2 환경에서 native query를 사용한 soft delete 검증 방식
    - 조건부 validation을 Exception.class로 검증하는 방식 (H2 예외 타입 차이)
  5. 코딩 컨벤션
    - Entity 필드명: 도메인 prefix 없이 사용 (id, not notificationId)
