### PR TITLE
Feat: 배송 단건 조회 api 구현

### DIFF
--- a/common-lib/src/main/java/com/oneforlogis/common/exception/ErrorCode.java
+++ b/common-lib/src/main/java/com/oneforlogis/common/exception/ErrorCode.java
@@ -47,7 +47,8 @@ public enum ErrorCode {
     // Order
 
     // Delivery
-
+    DELIVERY_NOT_FOUND(HttpStatus.NOT_FOUND, "배송을 찾을 수 없습니다."),
+    
     // Notification
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
     NOTIFICATION_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 발송에 실패했습니다."),

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/application/dto/DeliveryResponse.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/application/dto/DeliveryResponse.java
@@ -1,0 +1,78 @@
+package com.oneforlogis.delivery.application.dto;
+
+import com.oneforlogis.delivery.domain.model.Delivery;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DeliveryResponse {
+
+    private final UUID id;
+    private final UUID orderId;
+    private final String status;
+    private final UUID fromHubId;
+    private final UUID toHubId;
+
+    private final Double estimatedDistanceKm;
+    private final Integer estimatedDurationMin;
+    private final Boolean arrivedDestinationHub;
+
+    private final LocalDateTime destinationHubArrivedAt;
+    private final Long deliveryStaffId;
+    private final String receiverName;
+    private final String receiverAddress;
+    private final String receiverSlackId;
+
+    @Builder
+    public DeliveryResponse(
+            UUID id,
+            UUID orderId,
+            String status,
+            UUID fromHubId,
+            UUID toHubId,
+            Double estimatedDistanceKm,
+            Integer estimatedDurationMin,
+            Boolean arrivedDestinationHub,
+            LocalDateTime destinationHubArrivedAt,
+            Long deliveryStaffId,
+            String receiverName,
+            String receiverAddress,
+            String receiverSlackId
+    ) {
+        this.id = id;
+        this.orderId = orderId;
+        this.status = status;
+        this.fromHubId = fromHubId;
+        this.toHubId = toHubId;
+
+        this.estimatedDistanceKm = (estimatedDistanceKm != null) ? estimatedDistanceKm : 0.0;
+        this.estimatedDurationMin = (estimatedDurationMin != null) ? estimatedDurationMin : 0;
+        this.arrivedDestinationHub =
+                (arrivedDestinationHub != null) ? arrivedDestinationHub : false;
+
+        this.destinationHubArrivedAt = destinationHubArrivedAt;
+        this.deliveryStaffId = deliveryStaffId;
+        this.receiverName = receiverName;
+        this.receiverAddress = receiverAddress;
+        this.receiverSlackId = receiverSlackId;
+    }
+
+    public static DeliveryResponse from(Delivery d) {
+        return DeliveryResponse.builder()
+                .id(d.getDeliveryId())
+                .orderId(d.getOrderId())
+                .status(d.getStatus().name())
+                .fromHubId(UUID.fromString(d.getStartHubId()))
+                .toHubId(UUID.fromString(d.getDestinationHubId()))
+                .destinationHubArrivedAt(null)
+                .deliveryStaffId(
+                        d.getDeliveryStaffId() != null ? Long.valueOf(d.getDeliveryStaffId())
+                                : null)
+                .receiverName(d.getReceiverName())
+                .receiverAddress(d.getReceiverAddress())
+                .receiverSlackId(d.getReceiverSlackId())
+                .build();
+    }
+}

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/domain/model/Delivery.java
@@ -7,14 +7,15 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
 @Table(name = "p_deliveries", uniqueConstraints = {
         @UniqueConstraint(name = "uk_delivery_order", columnNames = {"order_id"})
 })
@@ -34,6 +35,18 @@ public class Delivery {
     @Column(name = "start_hub_id", nullable = false, length = 64)
     private String startHubId;
 
+    @Column(name = "estimated_distance_km")
+    private Double estimatedDistanceKm;
+
+    @Column(name = "estimated_duration_min")
+    private Integer estimatedDurationMin;
+
+    @Column(name = "arrived_destination_hub")
+    private Boolean arrivedDestinationHub;
+
+    @Column(name = "destination_hub_arrived_at")
+    private LocalDateTime destinationHubArrivedAt;
+
     @Column(name = "destination_hub_id", nullable = false, length = 64)
     private String destinationHubId;
 
@@ -49,9 +62,17 @@ public class Delivery {
     @Column(name = "delivery_staff_id", length = 64)
     private String deliveryStaffId;
 
-    private Delivery(UUID deliveryId, UUID orderId, DeliveryStatus status,
-            String startHubId, String destinationHubId,
-            String receiverName, String receiverAddress, String receiverSlackId) {
+    private Delivery(
+            UUID deliveryId,
+            UUID orderId,
+            DeliveryStatus status,
+            String startHubId,
+            String destinationHubId,
+            String receiverName,
+            String receiverAddress,
+            String receiverSlackId,
+            String deliveryStaffId
+    ) {
         this.deliveryId = deliveryId;
         this.orderId = orderId;
         this.status = status;
@@ -60,14 +81,22 @@ public class Delivery {
         this.receiverName = receiverName;
         this.receiverAddress = receiverAddress;
         this.receiverSlackId = receiverSlackId;
+        this.deliveryStaffId = deliveryStaffId;
+
+        this.estimatedDistanceKm = 0.0;
+        this.estimatedDurationMin = 0;
+        this.arrivedDestinationHub = false;
+        this.destinationHubArrivedAt = null;
     }
 
-    public static Delivery createFromOrder(UUID orderId,
+    public static Delivery createFromOrder(
+            UUID orderId,
             String startHubId,
             String destinationHubId,
             String receiverName,
             String receiverAddress,
-            String receiverSlackId) {
+            String receiverSlackId
+    ) {
         return new Delivery(
                 UUID.randomUUID(),
                 orderId,
@@ -76,7 +105,8 @@ public class Delivery {
                 destinationHubId,
                 receiverName,
                 receiverAddress,
-                receiverSlackId
+                receiverSlackId,
+                null
         );
     }
 }

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/domain/repository/DeliveryRepository.java
@@ -4,10 +4,14 @@ import com.oneforlogis.delivery.domain.model.Delivery;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
+public interface DeliveryRepository extends JpaRepository<Delivery, UUID>,
+        JpaSpecificationExecutor<Delivery> {
 
     boolean existsByOrderId(UUID orderId);
 
     Optional<Delivery> findByOrderId(UUID orderId);
+
+    Optional<Delivery> findByDeliveryId(UUID deliveryId);
 }

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/presentation/advice/DeliveryExceptionHandler.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/presentation/advice/DeliveryExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.oneforlogis.delivery.presentation.advice;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice
+public class DeliveryExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("isSuccess", false);
+        body.put("code", HttpStatus.NOT_FOUND.value());
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+}

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/presentation/controller/DeliveryController.java
@@ -1,0 +1,27 @@
+package com.oneforlogis.delivery.presentation.controller;
+
+import com.oneforlogis.delivery.application.dto.DeliveryResponse;
+import com.oneforlogis.delivery.application.service.DeliveryService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/deliveries")
+public class DeliveryController {
+
+    private final DeliveryService deliveryService;
+
+    @GetMapping("/{deliveryId}")
+    public ResponseEntity<DeliveryResponse> getDeliveryById(
+            @PathVariable UUID deliveryId
+    ) {
+        DeliveryResponse response = deliveryService.getOne(deliveryId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/delivery-service/src/test/java/com/oneforlogis/delivery/presentation/controller/DeliveryControllerTest.java
+++ b/delivery-service/src/test/java/com/oneforlogis/delivery/presentation/controller/DeliveryControllerTest.java
@@ -1,0 +1,82 @@
+package com.oneforlogis.delivery.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.oneforlogis.delivery.application.dto.DeliveryResponse;
+import com.oneforlogis.delivery.application.service.DeliveryService;
+import com.oneforlogis.delivery.presentation.advice.DeliveryExceptionHandler;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@Import(DeliveryExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(controllers = DeliveryController.class)
+class DeliveryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DeliveryService deliveryService;
+
+    private DeliveryResponse buildDeliveryResponse(UUID deliveryId) {
+        return DeliveryResponse.builder()
+                .id(deliveryId)
+                .orderId(UUID.randomUUID())
+                .status("WAITING_AT_HUB")
+                .fromHubId(UUID.randomUUID())
+                .toHubId(UUID.randomUUID())
+                .estimatedDistanceKm(0.0)
+                .estimatedDurationMin(0)
+                .arrivedDestinationHub(false)
+                .destinationHubArrivedAt(null)
+                .deliveryStaffId(null)
+                .receiverName("홍길동")
+                .receiverAddress("서울특별시 중구 을지로 100")
+                .receiverSlackId("U1234567")
+                .build();
+    }
+
+    @Test
+    @DisplayName("배송 단건 조회 성공")
+    void getDeliveryById_success() throws Exception {
+        // given
+        UUID deliveryId = UUID.randomUUID();
+        DeliveryResponse mockResponse = buildDeliveryResponse(deliveryId);
+        Mockito.when(deliveryService.getOne(any(UUID.class))).thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/deliveries/{deliveryId}", deliveryId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(deliveryId.toString()))
+                .andExpect(jsonPath("$.receiverName").value("홍길동"))
+                .andExpect(jsonPath("$.status").value("WAITING_AT_HUB"));
+    }
+
+    @Test
+    @DisplayName("배송 단건 조회 실패 - 존재하지 않는 ID")
+    void getDeliveryById_notFound() throws Exception {
+        // given
+        UUID deliveryId = UUID.randomUUID();
+        Mockito.when(deliveryService.getOne(any(UUID.class)))
+                .thenThrow(new IllegalArgumentException("해당 배송을 찾을 수 없습니다."));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/deliveries/{deliveryId}", deliveryId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError());
+    }
+}


### PR DESCRIPTION
## Issue Number
> closed #70 

## 📝 Description
- 배송 단건 조회 기능 구현 완료  
- 존재하지 않는 배송 ID 조회 시 `CustomException(ErrorCode.DELIVERY_NOT_FOUND)` 발생하도록 처리  
- `DeliveryResponse`를 통한 응답 DTO 반환  
- 커스텀 예외 기반 전역 예외 처리 적용 (`GlobalExceptionHandler` 사용)

## 🌐 Test Result
- 단건 조회 성공: `200 OK` + 배송 상세 정보 반환  
- 단건 조회 실패: 존재하지 않는 ID 요청 시 `404 NOT_FOUND` + `"해당 배송을 찾을 수 없습니다."` 응답  
- 테스트 통과 (`DeliveryControllerTest` 성공 확인)
<img width="899" height="298" alt="스크린샷 2025-11-11 02 01 43" src="https://github.com/user-attachments/assets/8f46f351-7d0a-48f5-a7a4-5187361073ee" />

## 🔎 To Reviewer
- `DeliveryResponse.from()` 변환 구조 개선 필요 여부 확인 부탁드립니다.
- PR 확인되면 목록 조회, 수정, 삭제도 바로 올리겠습니다!