### PR TITLE
fix: FeignClient 상태 값 오류 해결 및 hub <-> company client 통신 생성

### DIFF
--- a/common-lib/src/main/java/com/oneforlogis/common/exception/GlobalExceptionHandler.java
+++ b/common-lib/src/main/java/com/oneforlogis/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.oneforlogis.common.exception;
 import com.oneforlogis.common.api.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -15,60 +16,82 @@ import org.springframework.web.servlet.NoHandlerFoundException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * HTTP 상태 코드가 실제 Response에 반영되도록
+     */
+    // CustomException 처리
     @ExceptionHandler(CustomException.class)
-    protected ApiResponse<Void> handleBusinessException(CustomException e) {
+    protected ResponseEntity<ApiResponse<Void>> handleBusinessException(CustomException e) {
         ErrorCode errorCode = e.getErrorCode();
         HttpStatus status = errorCode.getHttpStatus();
         log.warn("[BusinessException] {} (status: {})", errorCode.getMessage(), status.value());
-        return new ApiResponse<>(false, status.value(), errorCode.getMessage(), null);
+
+        ApiResponse<Void> response = new ApiResponse<>(false, status.value(), errorCode.getMessage(), null);
+        return new ResponseEntity<>(response, status);
     }
 
+    // 요청 값 유효성 검증 실패
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ApiResponse<Void> handleMethodArgumentNotValid(
-            MethodArgumentNotValidException e) {
+    protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
         String message = e.getBindingResult().getFieldError() != null
                 ? e.getBindingResult().getFieldError().getDefaultMessage()
                 : "요청 값이 유효하지 않습니다.";
         log.warn("[ValidationError] {}", message);
         HttpStatus status = HttpStatus.BAD_REQUEST;
-        return new ApiResponse<>(false, status.value(), message, null);
+
+        ApiResponse<Void> response = new ApiResponse<>(false, status.value(), message, null);
+        return new ResponseEntity<>(response, status);
     }
 
     @ExceptionHandler(BindException.class)
-    protected ApiResponse<Void> handleBindException(BindException e) {
+    protected ResponseEntity<ApiResponse<Void>> handleBindException(BindException e) {
         String message = e.getBindingResult().getFieldError() != null
                 ? e.getBindingResult().getFieldError().getDefaultMessage()
                 : "요청 파라미터가 유효하지 않습니다.";
         log.warn("[BindError] {}", message);
         HttpStatus status = HttpStatus.BAD_REQUEST;
-        return new ApiResponse<>(false, status.value(), message, null);
+
+        ApiResponse<Void> response = new ApiResponse<>(false, status.value(), message, null);
+        return new ResponseEntity<>(response, status);
     }
 
+    // HTTP 메서드 지원 안됨
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    protected ApiResponse<Void> handleMethodNotSupported(
-            HttpRequestMethodNotSupportedException e) {
+    protected ResponseEntity<ApiResponse<Void>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
         log.warn("[METHOD_NOT_ALLOWED]", e);
         HttpStatus status = HttpStatus.METHOD_NOT_ALLOWED;
-        return new ApiResponse<>(false, status.value(), e.getMessage(), null);
+
+        ApiResponse<Void> response = new ApiResponse<>(false, status.value(), e.getMessage(), null);
+        return new ResponseEntity<>(response, status);
     }
 
+    // 핸들러 없음 (404)
     @ExceptionHandler(NoHandlerFoundException.class)
-    protected ApiResponse<Void> handleNotFound(NoHandlerFoundException e) {
+    protected ResponseEntity<ApiResponse<Void>> handleNotFound(NoHandlerFoundException e) {
         log.warn("[NOT_FOUND]", e);
         HttpStatus status = HttpStatus.NOT_FOUND;
-        return new ApiResponse<>(false, status.value(), e.getMessage(), null);
+
+        ApiResponse<Void> response = new ApiResponse<>(false, status.value(), e.getMessage(), null);
+        return new ResponseEntity<>(response, status);
     }
 
+    // 권한 없음
     @ExceptionHandler(AccessDeniedException.class)
-    public ApiResponse<Void> handleAccessDeniedException(AccessDeniedException e) {
+    public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException e) {
         ErrorCode errorCode = ErrorCode.FORBIDDEN_ACCESS;
-        return new ApiResponse<>(false, errorCode.getHttpStatus().value(), errorCode.getMessage(), null);
+        HttpStatus status = errorCode.getHttpStatus();
+
+        ApiResponse<Void> response = new ApiResponse<>(false, status.value(), errorCode.getMessage(), null);
+        return new ResponseEntity<>(response, status);
     }
 
+    // 그 외 서버 에러
     @ExceptionHandler(Exception.class)
-    protected ApiResponse<Void> handleException(Exception e) {
+    protected ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         log.error("[INTERNAL_SERVER_ERROR] {}", e.getMessage(), e);
         HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
-        return new ApiResponse<>(false, status.value(), e.getMessage(), null);
+
+        ApiResponse<Void> response = new ApiResponse<>(false, status.value(), e.getMessage(), null);
+        return new ResponseEntity<>(response, status);
     }
 }

--- a/company-service/build.gradle
+++ b/company-service/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.cloud:spring-cloud-starter-loadbalancer'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 

--- a/company-service/src/main/java/com/oneforlogis/company/infrastructure/client/CompanyClient.java
+++ b/company-service/src/main/java/com/oneforlogis/company/infrastructure/client/CompanyClient.java
@@ -1,2 +1,0 @@
-package com.oneforlogis.company.infrastructure.client;
-// CompanyClient

--- a/company-service/src/main/java/com/oneforlogis/company/infrastructure/client/HubClient.java
+++ b/company-service/src/main/java/com/oneforlogis/company/infrastructure/client/HubClient.java
@@ -1,0 +1,18 @@
+package com.oneforlogis.company.infrastructure.client;
+
+import com.oneforlogis.common.api.ApiResponse;
+import com.oneforlogis.company.infrastructure.client.dto.HubResponse;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+/**
+ * company <-> hub-service 통신 (외부 호출용 FeignClient)
+ */
+@FeignClient(name = "hub-service", path = "/api/v1/hubs")
+public interface HubClient {
+
+    @GetMapping("/{hubId}")
+    ApiResponse<HubResponse> getHub(@PathVariable UUID hubId);
+}

--- a/company-service/src/main/java/com/oneforlogis/company/infrastructure/client/dto/HubResponse.java
+++ b/company-service/src/main/java/com/oneforlogis/company/infrastructure/client/dto/HubResponse.java
@@ -1,0 +1,15 @@
+package com.oneforlogis.company.infrastructure.client.dto;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * FeignClient 응답 바인딩 DTO (Json -> hub 데이터 -> 매핑. record) : 실제 데이터 DTO
+ */
+public record HubResponse(
+        UUID id,
+        String name,
+        String address,
+        BigDecimal lat,
+        BigDecimal lon
+) {}

--- a/company-service/src/main/java/com/oneforlogis/company/presentation/controller/CompanyController.java
+++ b/company-service/src/main/java/com/oneforlogis/company/presentation/controller/CompanyController.java
@@ -49,7 +49,6 @@ public class CompanyController {
     @PreAuthorize("hasRole('MASTER') or hasRole('HUB_MANAGER')")
     @PostMapping
     public ResponseEntity<ApiResponse<CompanyCreateResponse>> createCompany(@RequestBody @Valid CompanyCreateRequest request){
-
         var response = companyService.createCompany(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
     }
@@ -60,26 +59,22 @@ public class CompanyController {
     @Operation(summary = "업체 수정", description = "업체 정보를 수정합니다. 'MASTER, HUB_MANAGER(담당 허브), COMPANY_MANAGER(담당 업체)' 권한이 필요합니다.")
     @PreAuthorize("hasRole('MASTER') or hasRole('HUB_MANAGER') or hasRole('COMPANY_MANAGER')")
     @PatchMapping("/{companyId}")
-    public ResponseEntity<ApiResponse<CompanyUpdateResponse>> updateCompany(@PathVariable UUID companyId,
+    public ApiResponse<CompanyUpdateResponse> updateCompany(@PathVariable UUID companyId,
             @RequestBody @Valid CompanyUpdateRequest request){
-
         var response = companyService.updateCompany(companyId, request);
-        return ResponseEntity.ok().body(ApiResponse.success(response));
+        return ApiResponse.success(response);
     }
 
     /**
      * 업체 정보 삭제
-     * + noContent도 메세지를 띄움 (ok) 처리
      */
     @Operation(summary = "업체 삭제", description = "업체를 삭제합니다. 'MASTER, HUB_MANAGER(담당 허브)' 권한이 필요합니다.")
     @PreAuthorize("hasRole('MASTER') or hasRole('HUB_MANAGER')")
     @DeleteMapping("/{companyId}")
     public ResponseEntity<ApiResponse<Void>> deleteCompany(@PathVariable UUID companyId,
-            @AuthenticationPrincipal UserPrincipal userPrincipal){
-
-        String userName = userPrincipal.username();
-        companyService.deleteCompany(companyId, userName);
-        return ResponseEntity.ok().body(ApiResponse.noContent());
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        companyService.deleteCompany(companyId, userPrincipal.username());
+        return ResponseEntity.noContent().build();
     }
 
     /**
@@ -87,9 +82,9 @@ public class CompanyController {
      */
     @Operation(summary = "업체 단건 조회", description = "업체 ID로 단일 업체 정보를 조회합니다.")
     @GetMapping("/{companyId}")
-    public ResponseEntity<ApiResponse<CompanyDetailResponse>> getCompanyDetail(@PathVariable UUID companyId) {
+    public ApiResponse<CompanyDetailResponse> getCompanyDetail(@PathVariable UUID companyId) {
         var response = companyService.getCompanyDetail(companyId);
-        return ResponseEntity.ok(ApiResponse.success(response));
+        return ApiResponse.success(response);
     }
 
     /**
@@ -103,7 +98,7 @@ public class CompanyController {
      */
     @Operation(summary = "업체 전체(검색) 조회", description = "업체 리스트를 조회합니다.")
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<CompanySearchResponse>>> getCompanies(
+    public ApiResponse<PageResponse<CompanySearchResponse>> getCompanies(
             @RequestParam(required = false) String companyName,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -112,6 +107,6 @@ public class CompanyController {
     ) {
         Page<CompanySearchResponse> companyPage = companyService.getCompanies(companyName, page, size, sortBy, isAsc)
                 .map(CompanySearchResponse::from);
-        return ResponseEntity.ok(ApiResponse.success(PageResponse.fromPage(companyPage)));
+        return ApiResponse.success(PageResponse.fromPage(companyPage));
     }
 }


### PR DESCRIPTION
## Issue Number
> closed #74 

## 📝 Description
- **Company Controller HTTP 상태 코드(200, 201, 204)가 실제로 적용되도록 전부 변경하였습니다.**
- 200 처리는 apiResponse만, 그 외는 (+)ResponseEntity
- **✅ GlobalExceptionHandler 파일 수정**

🔽 **문제 상황 1** 
```
company 생성 (유효한 hubId 필요) -> hub Client 호출로 hubId 검증 -> ⚠️ 검증 실패
```
🔽 **해결 과정**
`OpenFeign의 작동 방식` => **HTTP 상태 코드를 기준으로 성공/실패 판단**
**팀 컨벤션 ApiResponse를 사용할 때 응답 바디를 항상 포함하기 때문에 전부 200(OK)로 처리되고 있음**(바디에만 응답). 때문에 NotFound를 감지하더라도 HTTP 상태 코드는 200 OK이므로 예외를 잡지 못하고 성공으로 처리.
- 에러 핸들러에 ResponseEntity 반환 코드를 추가하여 제어 (404 Not Found) ✅

---

🔽 **문제 상황 2** 
Client 통신 테스트 중 기능은 정상 작동하는데 로그에는 허브 데이터가 null로 찍힘

🔽 **해결 과정**
Hub API는 ApiResponse<HubResponse> 형태로 응답하지만, HubClient에선 HubResponse로 매핑하고 있어서 내부 data 필드가 매핑되지 않았음 -> HubClient의 반환 타입을 ApiResponse<HubResponse>로 변경
`서비스 레이어에서 .data()를 통해 실제 Hub 데이터 접근하도록 수정 (디버깅용)`

## 🌐 Test Result

## 🔎 To Reviewer
- 다른 서비스 쪽에서도 일어날 오류 같아서 우선 중간 코드 올립니다. 해결 과정이 적절한 지 확인해주세요!
