### PR TITLE
feat: 배송 목록/검색 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ out/
 .env
 .env.docker
 **/application-local.yml
+
+init_dummy_data.sql

--- a/delivery-service/build.gradle
+++ b/delivery-service/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client"
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     runtimeOnly 'org.postgresql:postgresql'
     compileOnly 'org.projectlombok:lombok'

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/application/dto/DeliveryResponse.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/application/dto/DeliveryResponse.java
@@ -3,76 +3,52 @@ package com.oneforlogis.delivery.application.dto;
 import com.oneforlogis.delivery.domain.model.Delivery;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-public class DeliveryResponse {
+public record DeliveryResponse(
+        UUID id,
+        UUID orderId,
+        String status,
+        UUID fromHubId,
+        UUID toHubId,
+        // TODO: 경로/거리 계산 도메인 구현 후 매핑 예정
+        Double estimatedDistanceKm,
+        Integer estimatedDurationMin,
+        Boolean arrivedDestinationHub,
+        LocalDateTime destinationHubArrivedAt,
+        Long deliveryStaffId,
+        String receiverName,
+        String receiverAddress,
+        String receiverSlackId
+) {
 
-    private final UUID id;
-    private final UUID orderId;
-    private final String status;
-    private final UUID fromHubId;
-    private final UUID toHubId;
-
-    private final Double estimatedDistanceKm;
-    private final Integer estimatedDurationMin;
-    private final Boolean arrivedDestinationHub;
-
-    private final LocalDateTime destinationHubArrivedAt;
-    private final Long deliveryStaffId;
-    private final String receiverName;
-    private final String receiverAddress;
-    private final String receiverSlackId;
-
-    @Builder
-    public DeliveryResponse(
-            UUID id,
-            UUID orderId,
-            String status,
-            UUID fromHubId,
-            UUID toHubId,
-            Double estimatedDistanceKm,
-            Integer estimatedDurationMin,
-            Boolean arrivedDestinationHub,
-            LocalDateTime destinationHubArrivedAt,
-            Long deliveryStaffId,
-            String receiverName,
-            String receiverAddress,
-            String receiverSlackId
-    ) {
-        this.id = id;
-        this.orderId = orderId;
-        this.status = status;
-        this.fromHubId = fromHubId;
-        this.toHubId = toHubId;
-
-        this.estimatedDistanceKm = (estimatedDistanceKm != null) ? estimatedDistanceKm : 0.0;
-        this.estimatedDurationMin = (estimatedDurationMin != null) ? estimatedDurationMin : 0;
-        this.arrivedDestinationHub =
-                (arrivedDestinationHub != null) ? arrivedDestinationHub : false;
-
-        this.destinationHubArrivedAt = destinationHubArrivedAt;
-        this.deliveryStaffId = deliveryStaffId;
-        this.receiverName = receiverName;
-        this.receiverAddress = receiverAddress;
-        this.receiverSlackId = receiverSlackId;
+    // TODO: 계산 로직 연동 전까지 기본값 사용
+    public DeliveryResponse {
+        if (estimatedDistanceKm == null) {
+            estimatedDistanceKm = 0.0;
+        }
+        if (estimatedDurationMin == null) {
+            estimatedDurationMin = 0;
+        }
+        if (arrivedDestinationHub == null) {
+            arrivedDestinationHub = false;
+        }
     }
 
     public static DeliveryResponse from(Delivery d) {
-        return DeliveryResponse.builder()
-                .id(d.getDeliveryId())
-                .orderId(d.getOrderId())
-                .status(d.getStatus().name())
-                .fromHubId(UUID.fromString(d.getStartHubId()))
-                .toHubId(UUID.fromString(d.getDestinationHubId()))
-                .destinationHubArrivedAt(null)
-                .deliveryStaffId(
-                        d.getDeliveryStaffId() != null ? Long.valueOf(d.getDeliveryStaffId())
-                                : null)
-                .receiverName(d.getReceiverName())
-                .receiverAddress(d.getReceiverAddress())
-                .receiverSlackId(d.getReceiverSlackId())
-                .build();
+        return new DeliveryResponse(
+                d.getDeliveryId(),
+                d.getOrderId(),
+                d.getStatus().name(),
+                UUID.fromString(d.getStartHubId()),
+                UUID.fromString(d.getDestinationHubId()),
+                null,
+                null,
+                null,
+                null,
+                d.getDeliveryStaffId() != null ? Long.valueOf(d.getDeliveryStaffId()) : null,
+                d.getReceiverName(),
+                d.getReceiverAddress(),
+                d.getReceiverSlackId()
+        );
     }
 }

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/application/dto/DeliverySearchCond.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/application/dto/DeliverySearchCond.java
@@ -2,16 +2,13 @@ package com.oneforlogis.delivery.application.dto;
 
 import com.oneforlogis.delivery.domain.model.DeliveryStatus;
 import java.util.UUID;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@Builder
-public class DeliverySearchCond {
+public record DeliverySearchCond(
+        DeliveryStatus status,
+        String receiverName,
+        UUID orderId,
+        UUID fromHubId,
+        UUID toHubId
+) {
 
-    private final UUID orderId;
-    private final DeliveryStatus status;
-    private final String receiverName;
-    private final String startHubId;
-    private final String destinationHubId;
 }

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/application/dto/DeliverySearchCond.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/application/dto/DeliverySearchCond.java
@@ -1,0 +1,17 @@
+package com.oneforlogis.delivery.application.dto;
+
+import com.oneforlogis.delivery.domain.model.DeliveryStatus;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeliverySearchCond {
+
+    private final UUID orderId;
+    private final DeliveryStatus status;
+    private final String receiverName;
+    private final String startHubId;
+    private final String destinationHubId;
+}

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/application/service/DeliveryService.java
@@ -3,11 +3,15 @@ package com.oneforlogis.delivery.application.service;
 import com.oneforlogis.common.exception.CustomException;
 import com.oneforlogis.common.exception.ErrorCode;
 import com.oneforlogis.delivery.application.dto.DeliveryResponse;
+import com.oneforlogis.delivery.application.dto.DeliverySearchCond;
 import com.oneforlogis.delivery.application.event.OrderCreatedMessage;
 import com.oneforlogis.delivery.domain.model.Delivery;
 import com.oneforlogis.delivery.domain.repository.DeliveryRepository;
+import com.oneforlogis.delivery.infrastructure.repository.DeliverySpecifications;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,5 +48,13 @@ public class DeliveryService {
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_NOT_FOUND));
         return DeliveryResponse.from(delivery);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<DeliveryResponse> search(DeliverySearchCond cond, Pageable pageable) {
+        Page<Delivery> result = deliveryRepository.findAll(
+                DeliverySpecifications.search(cond), pageable
+        );
+        return result.map(DeliveryResponse::from);
     }
 }

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/application/service/DeliveryService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DeliveryService {
 
     private final DeliveryRepository deliveryRepository;
@@ -43,14 +44,12 @@ public class DeliveryService {
         return deliveryRepository.save(delivery).getDeliveryId();
     }
 
-    @Transactional(readOnly = true)
     public DeliveryResponse getOne(UUID deliveryId) {
         Delivery delivery = deliveryRepository.findById(deliveryId)
                 .orElseThrow(() -> new CustomException(ErrorCode.DELIVERY_NOT_FOUND));
         return DeliveryResponse.from(delivery);
     }
 
-    @Transactional(readOnly = true)
     public Page<DeliveryResponse> search(DeliverySearchCond cond, Pageable pageable) {
         Page<Delivery> result = deliveryRepository.findAll(
                 DeliverySpecifications.search(cond), pageable

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/config/SecurityConfig.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.oneforlogis.delivery.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/**", "/actuator/**").permitAll()
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+}

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/infrastructure/repository/DeliverySpecifications.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/infrastructure/repository/DeliverySpecifications.java
@@ -11,24 +11,26 @@ public class DeliverySpecifications {
         return (root, query, cb) -> {
             Predicate predicate = cb.conjunction();
 
-            if (cond.getStatus() != null) {
-                predicate = cb.and(predicate,
-                        cb.equal(root.get("status"), cond.getStatus()));
+            if (cond.status() != null) {
+                predicate = cb.and(predicate, cb.equal(root.get("status"), cond.status()));
             }
 
-            if (cond.getReceiverName() != null) {
+            if (cond.receiverName() != null && !cond.receiverName().isBlank()) {
                 predicate = cb.and(predicate,
-                        cb.like(root.get("receiverName"), "%" + cond.getReceiverName() + "%"));
+                        cb.like(root.get("receiverName"), "%" + cond.receiverName() + "%"));
             }
 
-            if (cond.getStartHubId() != null) {
-                predicate = cb.and(predicate,
-                        cb.equal(root.get("startHubId"), cond.getStartHubId()));
+            if (cond.orderId() != null) {
+                predicate = cb.and(predicate, cb.equal(root.get("orderId"), cond.orderId()));
             }
 
-            if (cond.getDestinationHubId() != null) {
+            if (cond.fromHubId() != null) {
+                predicate = cb.and(predicate, cb.equal(root.get("startHubId"), cond.fromHubId()));
+            }
+
+            if (cond.toHubId() != null) {
                 predicate = cb.and(predicate,
-                        cb.equal(root.get("destinationHubId"), cond.getDestinationHubId()));
+                        cb.equal(root.get("destinationHubId"), cond.toHubId()));
             }
 
             return predicate;

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/infrastructure/repository/DeliverySpecifications.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/infrastructure/repository/DeliverySpecifications.java
@@ -1,0 +1,37 @@
+package com.oneforlogis.delivery.infrastructure.repository;
+
+import com.oneforlogis.delivery.application.dto.DeliverySearchCond;
+import com.oneforlogis.delivery.domain.model.Delivery;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+public class DeliverySpecifications {
+
+    public static Specification<Delivery> search(DeliverySearchCond cond) {
+        return (root, query, cb) -> {
+            Predicate predicate = cb.conjunction();
+
+            if (cond.getStatus() != null) {
+                predicate = cb.and(predicate,
+                        cb.equal(root.get("status"), cond.getStatus()));
+            }
+
+            if (cond.getReceiverName() != null) {
+                predicate = cb.and(predicate,
+                        cb.like(root.get("receiverName"), "%" + cond.getReceiverName() + "%"));
+            }
+
+            if (cond.getStartHubId() != null) {
+                predicate = cb.and(predicate,
+                        cb.equal(root.get("startHubId"), cond.getStartHubId()));
+            }
+
+            if (cond.getDestinationHubId() != null) {
+                predicate = cb.and(predicate,
+                        cb.equal(root.get("destinationHubId"), cond.getDestinationHubId()));
+            }
+
+            return predicate;
+        };
+    }
+}

--- a/delivery-service/src/main/java/com/oneforlogis/delivery/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/oneforlogis/delivery/presentation/controller/DeliveryController.java
@@ -1,11 +1,15 @@
 package com.oneforlogis.delivery.presentation.controller;
 
 import com.oneforlogis.delivery.application.dto.DeliveryResponse;
+import com.oneforlogis.delivery.application.dto.DeliverySearchCond;
 import com.oneforlogis.delivery.application.service.DeliveryService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,5 +27,14 @@ public class DeliveryController {
     ) {
         DeliveryResponse response = deliveryService.getOne(deliveryId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<DeliveryResponse>> searchDeliveries(
+            @ModelAttribute DeliverySearchCond cond,
+            Pageable pageable
+    ) {
+        Page<DeliveryResponse> page = deliveryService.search(cond, pageable);
+        return ResponseEntity.ok(page);
     }
 }

--- a/delivery-service/src/main/resources/application.yml
+++ b/delivery-service/src/main/resources/application.yml
@@ -21,20 +21,20 @@ spring:
         format_sql: true
 
   kafka:
+    listener:
+      auto-startup: false
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-    consumer:
-      group-id: delivery-service
-      auto-offset-reset: latest
-      properties:
-        spring.json.trusted.packages: "com.oneforlogis.*"
 
-topics:
-  order-created: ${ORDER_CREATED_TOPIC:order.created}
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+      - org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration
 
 eureka:
   client:
-    register-with-eureka: true
-    fetch-registry: true
+    enabled: false
+    register-with-eureka: false
+    fetch-registry: false
     service-url:
       defaultZone: ${EUREKA_SERVER_URL:http://eureka-server:8761/eureka/}
 
@@ -46,4 +46,6 @@ management:
 
 logging:
   level:
+    org.apache.kafka.clients.NetworkClient: ERROR
+    com.netflix.discovery: WARN
     org.springframework: INFO

--- a/delivery-service/src/test/java/com/oneforlogis/delivery/infrastructure/kafka/OrderCreatedConsumerIT.java
+++ b/delivery-service/src/test/java/com/oneforlogis/delivery/infrastructure/kafka/OrderCreatedConsumerIT.java
@@ -19,11 +19,23 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+        "spring.autoconfigure.exclude=",
+        "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+        "spring.kafka.listener.auto-startup=true",
+        "spring.kafka.consumer.auto-offset-reset=earliest",
+        "spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer",
+        "spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer",
+        "spring.kafka.consumer.properties.spring.json.trusted.packages=com.oneforlogis.*",
+        "spring.kafka.consumer.properties.spring.json.value.default.type=com.oneforlogis.delivery.application.event.OrderCreatedMessage",
+        "eureka.client.enabled=false"
+})
 @ActiveProfiles("test")
 @EmbeddedKafka(partitions = 1, topics = {"order.created"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class OrderCreatedConsumerIT {
 
     @Autowired

--- a/delivery-service/src/test/java/com/oneforlogis/delivery/presentation/controller/DeliveryControllerTest.java
+++ b/delivery-service/src/test/java/com/oneforlogis/delivery/presentation/controller/DeliveryControllerTest.java
@@ -1,11 +1,13 @@
 package com.oneforlogis.delivery.presentation.controller;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.oneforlogis.delivery.application.dto.DeliveryResponse;
+import com.oneforlogis.delivery.application.dto.DeliverySearchCond;
 import com.oneforlogis.delivery.application.service.DeliveryService;
 import com.oneforlogis.delivery.presentation.advice.DeliveryExceptionHandler;
 import java.util.UUID;
@@ -17,6 +19,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -78,5 +84,57 @@ class DeliveryControllerTest {
         mockMvc.perform(get("/api/v1/deliveries/{deliveryId}", deliveryId)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().is4xxClientError());
+    }
+
+
+    @Test
+    @DisplayName("배송 목록/검색 조회 성공 - 조건/페이징")
+    void searchDeliveries_success() throws Exception {
+        // given
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        DeliveryResponse r1 = buildDeliveryResponse(id1);
+        DeliveryResponse r2 = buildDeliveryResponse(id2);
+
+        Page<DeliveryResponse> mockPage =
+                new PageImpl<>(java.util.List.of(r1, r2), PageRequest.of(0, 2), 2);
+
+        Mockito.when(deliveryService.search(any(DeliverySearchCond.class), any(Pageable.class)))
+                .thenReturn(mockPage);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/deliveries")
+                        .param("status", "WAITING_AT_HUB")
+                        .param("receiverName", "홍")
+                        .param("page", "0")
+                        .param("size", "2")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.content[0].id").value(id1.toString()))
+                .andExpect(jsonPath("$.content[1].id").value(id2.toString()))
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("배송 목록/검색 조회 - 결과 없음(빈 페이지)")
+    void searchDeliveries_empty() throws Exception {
+        // given
+        Page<DeliveryResponse> emptyPage =
+                new PageImpl<>(java.util.List.of(), PageRequest.of(0, 10), 0);
+
+        Mockito.when(deliveryService.search(any(DeliverySearchCond.class), any(Pageable.class)))
+                .thenReturn(emptyPage);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/deliveries")
+                        .param("status", "WAITING_AT_HUB")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(0)))
+                .andExpect(jsonPath("$.totalElements").value(0));
     }
 }

--- a/delivery-service/src/test/java/com/oneforlogis/delivery/presentation/controller/DeliveryControllerTest.java
+++ b/delivery-service/src/test/java/com/oneforlogis/delivery/presentation/controller/DeliveryControllerTest.java
@@ -10,6 +10,7 @@ import com.oneforlogis.delivery.application.dto.DeliveryResponse;
 import com.oneforlogis.delivery.application.dto.DeliverySearchCond;
 import com.oneforlogis.delivery.application.service.DeliveryService;
 import com.oneforlogis.delivery.presentation.advice.DeliveryExceptionHandler;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,21 +39,21 @@ class DeliveryControllerTest {
     private DeliveryService deliveryService;
 
     private DeliveryResponse buildDeliveryResponse(UUID deliveryId) {
-        return DeliveryResponse.builder()
-                .id(deliveryId)
-                .orderId(UUID.randomUUID())
-                .status("WAITING_AT_HUB")
-                .fromHubId(UUID.randomUUID())
-                .toHubId(UUID.randomUUID())
-                .estimatedDistanceKm(0.0)
-                .estimatedDurationMin(0)
-                .arrivedDestinationHub(false)
-                .destinationHubArrivedAt(null)
-                .deliveryStaffId(null)
-                .receiverName("홍길동")
-                .receiverAddress("서울특별시 중구 을지로 100")
-                .receiverSlackId("U1234567")
-                .build();
+        return new DeliveryResponse(
+                deliveryId,
+                UUID.randomUUID(),
+                "WAITING_AT_HUB",
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                0.0,
+                0,
+                false,
+                null,
+                null,
+                "홍길동",
+                "서울특별시 중구 을지로 100",
+                "U1234567"
+        );
     }
 
     @Test
@@ -115,6 +116,22 @@ class DeliveryControllerTest {
                 .andExpect(jsonPath("$.content[0].id").value(id1.toString()))
                 .andExpect(jsonPath("$.content[1].id").value(id2.toString()))
                 .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    @DisplayName("배송 목록/검색 조회 - 수령인 이름 부분검색")
+    void searchDeliveries_byReceiverName() throws Exception {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<DeliveryResponse> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+
+        Mockito.when(deliveryService.search(any(DeliverySearchCond.class), any(Pageable.class)))
+                .thenReturn(emptyPage);
+
+        mockMvc.perform(get("/api/v1/deliveries")
+                        .param("receiverName", "홍길")
+                        .param("page", "0").param("size", "10")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
     }
 
     @Test


### PR DESCRIPTION
## Issue Number
> closed #71

## 📝 Description
- 배송 목록/검색 조회 기능 구현
- `DeliverySearchCond` DTO 추가
- `DeliveryService`에 목록/검색 메서드 구현
- `DeliveryController`에 `/api/v1/deliveries` GET 엔드포인트 추가
- `DeliveryControllerTest`에 목록/검색 성공/결과없음 테스트 추가

## 🌐 Test Result
- 통합 테스트에서 `GET /api/v1/deliveries?status=WAITING_AT_HUB&page=0&size=10` 정상 응답 확인

## 🔎 To Reviewer
- `DeliverySpecifications` 구조가 JPA 표준에 맞게 잘 분리되었는지 확인 부탁드립니다.  
- `DeliverySearchCond`와 `DeliveryResponse`를 record로 전환했는데 추가 개선 포인트 있는지도 피드백 부탁드립니다.