### PR TITLE
feat: 알림 서비스 Kafka 연동

### DIFF
--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.kafka:spring-kafka'
 
     // Swagger/OpenAPI
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
@@ -29,6 +30,8 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test' // Security Test
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'com.h2database:h2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0' // MockWebServer
     testRuntimeOnly 'com.h2database:h2'

--- a/notification-service/scripts/test-notification-api.sh
+++ b/notification-service/scripts/test-notification-api.sh
@@ -51,12 +51,12 @@ function run_test() {
     echo -e "${BLUE}[TEST $TOTAL_TESTS] $test_name${NC}" | tee -a $RESULT_FILE
     echo "Request: $method $url" | tee -a $RESULT_FILE
 
-    # cURL 실행
+    # cURL 실행 (UTF-8 인코딩 명시)
     if [ -n "$data" ]; then
         response=$(curl -s -w "\n%{http_code}" -X $method "$url" \
-            -H "Content-Type: application/json" \
+            -H "Content-Type: application/json; charset=utf-8" \
             $headers \
-            -d "$data")
+            --data-binary "$data")
     else
         response=$(curl -s -w "\n%{http_code}" -X $method "$url" \
             $headers)

--- a/notification-service/src/main/java/com/oneforlogis/notification/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/NotificationServiceApplication.java
@@ -2,11 +2,13 @@ package com.oneforlogis.notification;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @EnableFeignClients
 @EnableDiscoveryClient
+@ConfigurationPropertiesScan
 @SpringBootApplication(scanBasePackages = "com.oneforlogis")
 public class NotificationServiceApplication {
 

--- a/notification-service/src/main/java/com/oneforlogis/notification/application/event/DeliveryStatusChangedEvent.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/application/event/DeliveryStatusChangedEvent.java
@@ -1,0 +1,21 @@
+package com.oneforlogis.notification.application.event;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record DeliveryStatusChangedEvent(
+        String eventId,
+        OffsetDateTime occurredAt,
+        DeliveryData delivery
+) {
+
+    public record DeliveryData(
+            UUID deliveryId,
+            UUID orderId,
+            String previousStatus,
+            String currentStatus,
+            String recipientSlackId,
+            String recipientName
+    ) {
+    }
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/application/event/OrderCreatedEvent.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/application/event/OrderCreatedEvent.java
@@ -1,0 +1,47 @@
+package com.oneforlogis.notification.application.event;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record OrderCreatedEvent(
+        String eventId,
+        OffsetDateTime occurredAt,
+        OrderData order
+) {
+
+    public record OrderData(
+            UUID orderId,
+            String ordererInfo,
+            String requestingCompanyName,
+            String receivingCompanyName,
+            String productInfo,
+            String requestDetails,
+            RouteData route,
+            ReceiverData receiver,
+            HubManagerData hubManager
+    ) {
+    }
+
+    public record RouteData(
+            UUID startHubId,
+            String startHubName,
+            List<String> waypointHubNames,
+            UUID destinationHubId,
+            String destinationHubName
+    ) {
+    }
+
+    public record ReceiverData(
+            String name,
+            String address,
+            String slackId
+    ) {
+    }
+
+    public record HubManagerData(
+            String slackId,
+            String name
+    ) {
+    }
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/model/MessageType.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/model/MessageType.java
@@ -9,6 +9,7 @@ public enum MessageType {
     // 일일 경로 최적화 알림 (Challenge 기능, 매일 06:00)
     DAILY_ROUTE,
 
-    // 사용자가 직접 발송하는 수동 메시지
+    DELIVERY_STATUS_UPDATE, // 사용자가 직접 발송하는 수동 메시지
+
     MANUAL
 }

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/model/Notification.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/model/Notification.java
@@ -62,6 +62,10 @@ public class Notification extends BaseEntity {
     @Column(name = "reference_id")
     private UUID referenceId;
 
+    // Kafka 이벤트 ID (멱등성 보장용, Kafka 이벤트 기반 알림만 사용)
+    @Column(name = "event_id", unique = true, length = 100)
+    private String eventId;
+
     // 발송 시각
     @Column(name = "sent_at")
     private LocalDateTime sentAt;
@@ -85,7 +89,8 @@ public class Notification extends BaseEntity {
             String recipientName,
             String messageContent,
             MessageType messageType,
-            UUID referenceId
+            UUID referenceId,
+            String eventId
     ) {
         this.id = UUID.randomUUID();
         this.senderType = senderType;
@@ -97,6 +102,7 @@ public class Notification extends BaseEntity {
         this.messageContent = messageContent;
         this.messageType = messageType;
         this.referenceId = referenceId;
+        this.eventId = eventId;
         this.status = MessageStatus.PENDING;
     }
 

--- a/notification-service/src/main/java/com/oneforlogis/notification/domain/repository/NotificationRepository.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/domain/repository/NotificationRepository.java
@@ -62,6 +62,16 @@ public interface NotificationRepository {
     List<Notification> findBySenderUsername(String senderUsername);
 
     /**
+     * Kafka 이벤트 ID로 알림 존재 여부 확인 (멱등성 체크)
+     */
+    boolean existsByEventId(String eventId);
+
+    /**
+     * Kafka 이벤트 ID로 알림 조회
+     */
+    Optional<Notification> findByEventId(String eventId);
+
+    /**
      * 알림 삭제 (Soft Delete)
      */
     void delete(Notification notification);

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/config/KafkaConsumerConfig.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,88 @@
+package com.oneforlogis.notification.infrastructure.config;
+
+import com.oneforlogis.notification.application.event.DeliveryStatusChangedEvent;
+import com.oneforlogis.notification.application.event.OrderCreatedEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Value("${spring.kafka.consumer.auto-offset-reset}")
+    private String autoOffsetReset;
+
+    // OrderCreatedEvent용 ConsumerFactory
+    @Bean
+    public ConsumerFactory<String, OrderCreatedEvent> orderCreatedConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName());
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, OrderCreatedEvent.class.getName());
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.oneforlogis.*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+
+        return new DefaultKafkaConsumerFactory<>(
+                props,
+                new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(new JsonDeserializer<>(OrderCreatedEvent.class, false))
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, OrderCreatedEvent> orderCreatedKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, OrderCreatedEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(orderCreatedConsumerFactory());
+        return factory;
+    }
+
+    // DeliveryStatusChangedEvent용 ConsumerFactory
+    @Bean
+    public ConsumerFactory<String, DeliveryStatusChangedEvent> deliveryStatusChangedConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName());
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, DeliveryStatusChangedEvent.class.getName());
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.oneforlogis.*");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+
+        return new DefaultKafkaConsumerFactory<>(
+                props,
+                new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(new JsonDeserializer<>(DeliveryStatusChangedEvent.class, false))
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, DeliveryStatusChangedEvent> deliveryStatusChangedKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, DeliveryStatusChangedEvent> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(deliveryStatusChangedConsumerFactory());
+        return factory;
+    }
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/config/TopicProperties.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/config/TopicProperties.java
@@ -1,0 +1,28 @@
+package com.oneforlogis.notification.infrastructure.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "topics")
+public class TopicProperties {
+
+    private String orderCreated = "order.created";
+    private String deliveryStatusChanged = "delivery.status.changed";
+
+    public String getOrderCreated() {
+        return orderCreated;
+    }
+
+    public void setOrderCreated(String orderCreated) {
+        this.orderCreated = orderCreated;
+    }
+
+    public String getDeliveryStatusChanged() {
+        return deliveryStatusChanged;
+    }
+
+    public void setDeliveryStatusChanged(String deliveryStatusChanged) {
+        this.deliveryStatusChanged = deliveryStatusChanged;
+    }
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/kafka/DeliveryStatusChangedConsumer.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/kafka/DeliveryStatusChangedConsumer.java
@@ -1,0 +1,113 @@
+package com.oneforlogis.notification.infrastructure.kafka;
+
+import com.oneforlogis.notification.application.event.DeliveryStatusChangedEvent;
+import com.oneforlogis.notification.domain.model.MessageType;
+import com.oneforlogis.notification.domain.model.Notification;
+import com.oneforlogis.notification.domain.model.SenderType;
+import com.oneforlogis.notification.domain.repository.NotificationRepository;
+import com.oneforlogis.notification.infrastructure.client.SlackClientWrapper;
+import com.oneforlogis.notification.infrastructure.client.slack.SlackMessageRequest;
+import com.oneforlogis.notification.infrastructure.client.slack.SlackMessageResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeliveryStatusChangedConsumer {
+
+    private final NotificationRepository notificationRepository;
+    private final SlackClientWrapper slackClientWrapper;
+
+    @KafkaListener(
+            topics = "#{@topicProperties.deliveryStatusChanged}",
+            groupId = "notification-service"
+    )
+    @Transactional
+    public void onMessage(DeliveryStatusChangedEvent event) {
+        log.info("🚚 Received delivery.status.changed event - eventId: {}, deliveryId: {}, status: {} → {}",
+                event.eventId(), event.delivery().deliveryId(),
+                event.delivery().previousStatus(), event.delivery().currentStatus());
+
+        try {
+            // 멱등성 체크: 이미 처리된 이벤트인지 확인
+            if (notificationRepository.existsByEventId(event.eventId())) {
+                log.info("⏭️ Event already processed (idempotency) - eventId: {}, deliveryId: {}",
+                        event.eventId(), event.delivery().deliveryId());
+                return;
+            }
+
+            var delivery = event.delivery();
+
+            // Slack 메시지 생성
+            String message = buildStatusChangeMessage(delivery);
+
+            // Notification 엔티티 생성 (SYSTEM 타입, eventId 포함)
+            Notification notification = Notification.builder()
+                    .senderType(SenderType.SYSTEM)
+                    .senderUsername(null)
+                    .senderSlackId(null)
+                    .senderName(null)
+                    .recipientSlackId(delivery.recipientSlackId())
+                    .recipientName(delivery.recipientName())
+                    .messageContent(message)
+                    .messageType(MessageType.DELIVERY_STATUS_UPDATE)
+                    .referenceId(delivery.deliveryId())
+                    .eventId(event.eventId())  // 멱등성 보장용 eventId 저장
+                    .build();
+
+            Notification savedNotification = notificationRepository.save(notification);
+
+            // Slack 메시지 발송
+            SlackMessageRequest slackRequest = SlackMessageRequest.builder()
+                    .channel(delivery.recipientSlackId())
+                    .text(message)
+                    .build();
+
+            SlackMessageResponse slackResponse = slackClientWrapper.postMessage(
+                    slackRequest,
+                    savedNotification.getId()
+            );
+
+            // 발송 상태 업데이트
+            if (slackResponse != null && slackResponse.isOk()) {
+                savedNotification.markAsSent();
+                log.info("✅ Delivery status notification sent - deliveryId: {}, notificationId: {}",
+                        delivery.deliveryId(), savedNotification.getId());
+            } else {
+                String error = slackResponse != null ? slackResponse.getError() : "Unknown error";
+                savedNotification.markAsFailed(error);
+                log.error("❌ Failed to send delivery status notification - deliveryId: {}, error: {}",
+                        delivery.deliveryId(), error);
+            }
+
+        } catch (Exception e) {
+            log.error("❌ Failed to process delivery.status.changed event - eventId: {}, deliveryId: {}, error: {}",
+                    event.eventId(), event.delivery().deliveryId(), e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    private String buildStatusChangeMessage(DeliveryStatusChangedEvent.DeliveryData delivery) {
+        return String.format(
+                """
+                🚚 *배송 상태 업데이트*
+
+                배송 ID: `%s`
+                주문 ID: `%s`
+                이전 상태: `%s`
+                현재 상태: `%s`
+
+                수령인: %s
+                """,
+                delivery.deliveryId(),
+                delivery.orderId(),
+                delivery.previousStatus(),
+                delivery.currentStatus(),
+                delivery.recipientName()
+        );
+    }
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/kafka/OrderCreatedConsumer.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/kafka/OrderCreatedConsumer.java
@@ -1,0 +1,81 @@
+package com.oneforlogis.notification.infrastructure.kafka;
+
+import com.oneforlogis.notification.application.event.OrderCreatedEvent;
+import com.oneforlogis.notification.application.service.NotificationService;
+import com.oneforlogis.notification.domain.repository.NotificationRepository;
+import com.oneforlogis.notification.presentation.request.OrderNotificationRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCreatedConsumer {
+
+    private final NotificationService notificationService;
+    private final NotificationRepository notificationRepository;
+
+    @KafkaListener(
+            topics = "#{@topicProperties.orderCreated}",
+            groupId = "notification-service"
+    )
+    public void onMessage(OrderCreatedEvent event) {
+        log.info("📦 Received order.created event - eventId: {}, orderId: {}",
+                event.eventId(), event.order().orderId());
+
+        try {
+            // 멱등성 체크: 이미 처리된 이벤트인지 확인
+            if (notificationRepository.existsByEventId(event.eventId())) {
+                log.info("⏭️ Event already processed (idempotency) - eventId: {}, orderId: {}",
+                        event.eventId(), event.order().orderId());
+                return;
+            }
+
+            // OrderCreatedEvent → OrderNotificationRequest 변환
+            OrderNotificationRequest request = convertToRequest(event);
+
+            // 주문 알림 발송 (내부에서 eventId를 Notification에 저장해야 함)
+            notificationService.sendOrderNotificationFromEvent(request, event.eventId());
+
+            log.info("✅ Order notification sent successfully - orderId: {}", event.order().orderId());
+
+        } catch (Exception e) {
+            log.error("❌ Failed to send order notification - eventId: {}, orderId: {}, error: {}",
+                    event.eventId(), event.order().orderId(), e.getMessage(), e);
+            // 예외를 던져서 Kafka가 재시도하도록 함
+            throw e;
+        }
+    }
+
+    private OrderNotificationRequest convertToRequest(OrderCreatedEvent event) {
+        var order = event.order();
+        var route = order.route();
+        var receiver = order.receiver();
+        var hubManager = order.hubManager();
+
+        // waypoint hub names를 그대로 전달 (List<String>)
+        List<String> waypoints = route.waypointHubNames() != null
+                ? route.waypointHubNames()
+                : List.of();
+
+        return new OrderNotificationRequest(
+                order.orderId(),
+                order.ordererInfo(),
+                order.requestingCompanyName(),
+                order.receivingCompanyName(),
+                order.productInfo(),
+                order.requestDetails(),
+                route.startHubName(),
+                waypoints,
+                route.destinationHubName(),
+                receiver.address(),
+                String.format("%s / %s", receiver.name(), receiver.slackId()),
+                hubManager.slackId(),
+                hubManager.name()
+        );
+    }
+}

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/kafka/OrderCreatedConsumer.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/kafka/OrderCreatedConsumer.java
@@ -21,7 +21,8 @@ public class OrderCreatedConsumer {
 
     @KafkaListener(
             topics = "#{@topicProperties.orderCreated}",
-            groupId = "notification-service"
+            groupId = "notification-service",
+            containerFactory = "orderCreatedKafkaListenerContainerFactory"
     )
     public void onMessage(OrderCreatedEvent event) {
         log.info("📦 Received order.created event - eventId: {}, orderId: {}",

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/NotificationJpaRepository.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/NotificationJpaRepository.java
@@ -6,6 +6,7 @@ import com.oneforlogis.notification.domain.model.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -38,4 +39,14 @@ public interface NotificationJpaRepository extends JpaRepository<Notification, U
      * 발신자 사용자명으로 알림 조회
      */
     List<Notification> findBySenderUsername(String senderUsername);
+
+    /**
+     * Kafka 이벤트 ID로 알림 존재 여부 확인 (멱등성 체크)
+     */
+    boolean existsByEventId(String eventId);
+
+    /**
+     * Kafka 이벤트 ID로 알림 조회
+     */
+    Optional<Notification> findByEventId(String eventId);
 }

--- a/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/NotificationRepositoryImpl.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/infrastructure/persistence/NotificationRepositoryImpl.java
@@ -67,6 +67,16 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     }
 
     @Override
+    public boolean existsByEventId(String eventId) {
+        return jpaRepository.existsByEventId(eventId);
+    }
+
+    @Override
+    public Optional<Notification> findByEventId(String eventId) {
+        return jpaRepository.findByEventId(eventId);
+    }
+
+    @Override
     public void delete(Notification notification) {
         notification.markAsDeleted("SYSTEM"); // TODO: 실제 사용자 정보로 변경
         jpaRepository.save(notification);

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -36,6 +36,23 @@ spring:
       circuitbreaker:
         enabled: true
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: notification-service
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        spring.json.trusted.packages: "com.oneforlogis.*"
+        spring.json.use.type.headers: false
+        spring.json.value.default.type: "com.oneforlogis.notification.application.event.OrderCreatedEvent"
+
+topics:
+  order-created: ${ORDER_CREATED_TOPIC:order.created}
+  delivery-status-changed: ${DELIVERY_STATUS_CHANGED_TOPIC:delivery.status.changed}
+
 management:
   endpoints:
     web:

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -41,13 +41,6 @@ spring:
     consumer:
       group-id: notification-service
       auto-offset-reset: latest
-      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
-      properties:
-        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
-        spring.json.trusted.packages: "com.oneforlogis.*"
-        spring.json.use.type.headers: false
-        spring.json.value.default.type: "com.oneforlogis.notification.application.event.OrderCreatedEvent"
 
 topics:
   order-created: ${ORDER_CREATED_TOPIC:order.created}

--- a/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/client/gemini/GeminiApiKeyIntegrationTest.java
+++ b/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/client/gemini/GeminiApiKeyIntegrationTest.java
@@ -13,7 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Gemini API 키 검증 통합 테스트
  * 실제 Gemini API를 호출하여 API Key의 유효성을 검증합니다.
  */
-@SpringBootTest
+@SpringBootTest(properties = {
+        "spring.kafka.bootstrap-servers=localhost:19092"  // 존재하지 않는 포트 (Kafka 비활성화)
+})
 @ActiveProfiles("test")
 class GeminiApiKeyIntegrationTest {
 

--- a/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/client/slack/SlackApiAuthIntegrationTest.java
+++ b/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/client/slack/SlackApiAuthIntegrationTest.java
@@ -17,7 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Slack API 키 검증 통합 테스트
  * 실제 Slack API를 호출하여 Bot Token의 유효성을 검증합니다.
  */
-@SpringBootTest
+@SpringBootTest(properties = {
+        "spring.kafka.bootstrap-servers=localhost:19092"  // 존재하지 않는 포트 (Kafka 비활성화)
+})
 @ActiveProfiles("test")
 class SlackApiAuthIntegrationTest {
 

--- a/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/kafka/DeliveryStatusChangedConsumerIT.java
+++ b/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/kafka/DeliveryStatusChangedConsumerIT.java
@@ -1,0 +1,214 @@
+package com.oneforlogis.notification.infrastructure.kafka;
+
+import com.oneforlogis.notification.application.event.DeliveryStatusChangedEvent;
+import com.oneforlogis.notification.domain.model.MessageType;
+import com.oneforlogis.notification.domain.repository.NotificationRepository;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {"delivery.status.changed"}
+)
+@DisplayName("DeliveryStatusChangedConsumer 통합 테스트")
+class DeliveryStatusChangedConsumerIT {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Value("${spring.embedded.kafka.brokers}")
+    private String brokers;
+
+    // 외부 API는 Mock으로 대체
+    @MockBean
+    private com.oneforlogis.notification.infrastructure.client.SlackClientWrapper slackClientWrapper;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 간 격리: DB 초기화
+        notificationRepository.findAll().forEach(notificationRepository::delete);
+    }
+
+    // delivery-service 패턴: 인라인 KafkaTemplate 생성
+    private KafkaTemplate<String, Object> kafkaTemplate() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(props));
+    }
+
+    @Test
+    @DisplayName("delivery.status.changed 이벤트 수신 시 알림 생성")
+    void shouldCreateNotificationWhenDeliveryStatusChangedEventReceived() {
+        // Given: 배송 상태 변경 이벤트
+        KafkaTemplate<String, Object> template = kafkaTemplate();
+
+        UUID deliveryId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String eventId = "delivery-event-" + UUID.randomUUID();
+
+        DeliveryStatusChangedEvent event = new DeliveryStatusChangedEvent(
+                eventId,
+                OffsetDateTime.now(),
+                new DeliveryStatusChangedEvent.DeliveryData(
+                        deliveryId,
+                        orderId,
+                        "HUB_WAITING",
+                        "HUB_MOVING",
+                        "U01234567",
+                        "Test Hub Manager"
+                )
+        );
+
+        // When: Kafka 이벤트 발행
+        template.send("delivery.status.changed", eventId, event);
+
+        // Then: 알림이 생성되었는지 확인 (비동기 처리 대기)
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    assertThat(notificationRepository.existsByEventId(eventId)).isTrue();
+
+                    // MessageType이 DELIVERY_STATUS_UPDATE인지 확인
+                    notificationRepository.findAll().stream()
+                            .filter(n -> eventId.equals(n.getEventId()))
+                            .findFirst()
+                            .ifPresent(notification -> {
+                                assertThat(notification.getMessageType()).isEqualTo(MessageType.DELIVERY_STATUS_UPDATE);
+                                assertThat(notification.getMessageContent()).contains("배송 상태 업데이트");
+                                assertThat(notification.getMessageContent()).contains("HUB_WAITING");
+                                assertThat(notification.getMessageContent()).contains("HUB_MOVING");
+                            });
+                });
+    }
+
+    @Test
+    @DisplayName("동일한 eventId로 중복 이벤트 수신 시 멱등성 보장")
+    void shouldEnsureIdempotencyWhenDuplicateEventReceived() {
+        // Given: 동일한 eventId를 가진 이벤트
+        KafkaTemplate<String, Object> template = kafkaTemplate();
+
+        UUID deliveryId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+        String eventId = "duplicate-delivery-event-" + UUID.randomUUID();
+
+        DeliveryStatusChangedEvent event = new DeliveryStatusChangedEvent(
+                eventId,
+                OffsetDateTime.now(),
+                new DeliveryStatusChangedEvent.DeliveryData(
+                        deliveryId,
+                        orderId,
+                        "HUB_MOVING",
+                        "HUB_ARRIVED",
+                        "U98765432",
+                        "Another Manager"
+                )
+        );
+
+        // When: 동일한 이벤트를 2번 발행
+        template.send("delivery.status.changed", eventId, event);
+        template.send("delivery.status.changed", eventId, event);
+
+        // Then: 1개의 알림만 생성되었는지 확인
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    long count = notificationRepository.findAll().stream()
+                            .filter(n -> eventId.equals(n.getEventId()))
+                            .count();
+                    assertThat(count).isEqualTo(1);
+                });
+    }
+
+    @Test
+    @DisplayName("다양한 배송 상태 변경 시나리오 테스트")
+    void shouldHandleVariousStatusChanges() {
+        // Given: 여러 배송 상태 변경 이벤트
+        KafkaTemplate<String, Object> template = kafkaTemplate();
+
+        UUID deliveryId = UUID.randomUUID();
+        UUID orderId = UUID.randomUUID();
+
+        // Scenario 1: HUB_WAITING → HUB_MOVING
+        String eventId1 = "status-event-1-" + UUID.randomUUID();
+        DeliveryStatusChangedEvent event1 = new DeliveryStatusChangedEvent(
+                eventId1,
+                OffsetDateTime.now(),
+                new DeliveryStatusChangedEvent.DeliveryData(
+                        deliveryId, orderId,
+                        "HUB_WAITING", "HUB_MOVING",
+                        "C09QY22AMEE", "Hub Manager 1"
+                )
+        );
+
+        // Scenario 2: HUB_MOVING → HUB_ARRIVED
+        String eventId2 = "status-event-2-" + UUID.randomUUID();
+        DeliveryStatusChangedEvent event2 = new DeliveryStatusChangedEvent(
+                eventId2,
+                OffsetDateTime.now(),
+                new DeliveryStatusChangedEvent.DeliveryData(
+                        deliveryId, orderId,
+                        "HUB_MOVING", "HUB_ARRIVED",
+                        "C09QY22AMEE", "Hub Manager 2"
+                )
+        );
+
+        // Scenario 3: HUB_ARRIVED → DELIVERING
+        String eventId3 = "status-event-3-" + UUID.randomUUID();
+        DeliveryStatusChangedEvent event3 = new DeliveryStatusChangedEvent(
+                eventId3,
+                OffsetDateTime.now(),
+                new DeliveryStatusChangedEvent.DeliveryData(
+                        deliveryId, orderId,
+                        "HUB_ARRIVED", "DELIVERING",
+                        "U11111111", "Delivery Person"
+                )
+        );
+
+        // When: 여러 이벤트 발행
+        template.send("delivery.status.changed", eventId1, event1);
+        template.send("delivery.status.changed", eventId2, event2);
+        template.send("delivery.status.changed", eventId3, event3);
+
+        // Then: 3개의 알림이 모두 생성되었는지 확인
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    assertThat(notificationRepository.existsByEventId(eventId1)).isTrue();
+                    assertThat(notificationRepository.existsByEventId(eventId2)).isTrue();
+                    assertThat(notificationRepository.existsByEventId(eventId3)).isTrue();
+
+                    long count = notificationRepository.findAll().stream()
+                            .filter(n -> n.getMessageType() == MessageType.DELIVERY_STATUS_UPDATE)
+                            .count();
+                    assertThat(count).isGreaterThanOrEqualTo(3);
+                });
+    }
+}

--- a/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/kafka/OrderCreatedConsumerIT.java
+++ b/notification-service/src/test/java/com/oneforlogis/notification/infrastructure/kafka/OrderCreatedConsumerIT.java
@@ -1,0 +1,170 @@
+package com.oneforlogis.notification.infrastructure.kafka;
+
+import com.oneforlogis.notification.application.event.OrderCreatedEvent;
+import com.oneforlogis.notification.domain.repository.NotificationRepository;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EmbeddedKafka(
+        partitions = 1,
+        topics = {"order.created"}
+)
+@DisplayName("OrderCreatedConsumer 통합 테스트")
+class OrderCreatedConsumerIT {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Value("${spring.embedded.kafka.brokers}")
+    private String brokers;
+
+    // 외부 API는 Mock으로 대체
+    @MockBean
+    private com.oneforlogis.notification.infrastructure.client.SlackClientWrapper slackClientWrapper;
+
+    @MockBean
+    private com.oneforlogis.notification.infrastructure.client.GeminiClientWrapper geminiClientWrapper;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 간 격리: DB 초기화
+        notificationRepository.findAll().forEach(notificationRepository::delete);
+    }
+
+    // delivery-service 패턴: 인라인 KafkaTemplate 생성
+    private KafkaTemplate<String, Object> kafkaTemplate() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(props));
+    }
+
+    @Test
+    @DisplayName("order.created 이벤트 수신 시 알림 생성")
+    void shouldCreateNotificationWhenOrderCreatedEventReceived() {
+        // Given: 주문 생성 이벤트
+        KafkaTemplate<String, Object> template = kafkaTemplate();
+
+        UUID orderId = UUID.randomUUID();
+        String eventId = "event-" + UUID.randomUUID();
+
+        OrderCreatedEvent event = new OrderCreatedEvent(
+                eventId,
+                OffsetDateTime.now(),
+                new OrderCreatedEvent.OrderData(
+                        orderId,
+                        "홍길동 / hong@test.com",
+                        "공급업체A",
+                        "수령업체B",
+                        "상품 10개",
+                        "빠른 배송 부탁드립니다",
+                        new OrderCreatedEvent.RouteData(
+                                UUID.randomUUID(),
+                                "서울센터",
+                                List.of("대전센터"),
+                                UUID.randomUUID(),
+                                "부산센터"
+                        ),
+                        new OrderCreatedEvent.ReceiverData(
+                                "김수령",
+                                "부산시 해운대구",
+                                "U01234567"
+                        ),
+                        new OrderCreatedEvent.HubManagerData(
+                                "U98765432",
+                                "박관리"
+                        )
+                )
+        );
+
+        // When: Kafka 이벤트 발행
+        template.send("order.created", eventId, event);
+
+        // Then: 알림이 생성되었는지 확인 (비동기 처리 대기)
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    assertThat(notificationRepository.existsByEventId(eventId)).isTrue();
+                });
+    }
+
+    @Test
+    @DisplayName("동일한 eventId로 중복 이벤트 수신 시 멱등성 보장")
+    void shouldEnsureIdempotencyWhenDuplicateEventReceived() {
+        // Given: 동일한 eventId를 가진 이벤트
+        KafkaTemplate<String, Object> template = kafkaTemplate();
+
+        UUID orderId = UUID.randomUUID();
+        String eventId = "duplicate-event-" + UUID.randomUUID();
+
+        OrderCreatedEvent event = new OrderCreatedEvent(
+                eventId,
+                OffsetDateTime.now(),
+                new OrderCreatedEvent.OrderData(
+                        orderId,
+                        "홍길동 / hong@test.com",
+                        "공급업체A",
+                        "수령업체B",
+                        "상품 10개",
+                        "빠른 배송 부탁드립니다",
+                        new OrderCreatedEvent.RouteData(
+                                UUID.randomUUID(),
+                                "서울센터",
+                                List.of("대전센터"),
+                                UUID.randomUUID(),
+                                "부산센터"
+                        ),
+                        new OrderCreatedEvent.ReceiverData(
+                                "김수령",
+                                "부산시 해운대구",
+                                "U01234567"
+                        ),
+                        new OrderCreatedEvent.HubManagerData(
+                                "U98765432",
+                                "박관리"
+                        )
+                )
+        );
+
+        // When: 동일한 이벤트를 2번 발행
+        template.send("order.created", eventId, event);
+        template.send("order.created", eventId, event);
+
+        // Then: 1개의 알림만 생성되었는지 확인
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    long count = notificationRepository.findAll().stream()
+                            .filter(n -> eventId.equals(n.getEventId()))
+                            .count();
+                    assertThat(count).isEqualTo(1);
+                });
+    }
+}

--- a/notification-service/src/test/resources/application-test.yml
+++ b/notification-service/src/test/resources/application-test.yml
@@ -24,6 +24,19 @@ spring:
     console:
       enabled: true
 
+  kafka:
+    bootstrap-servers: ${spring.embedded.kafka.brokers}
+    consumer:
+      group-id: notification-service-test
+      auto-offset-reset: earliest
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+topics:
+  order-created: order.created
+  delivery-status-changed: delivery.status.changed
+
 # Eureka 비활성화 (테스트 환경)
 eureka:
   client:


### PR DESCRIPTION
## Issue Number
> closed #35

## 📝 Description

notification-service에 Kafka Event Consumer를 구현하여 order-service와 delivery-service로부터 이벤트를 수신하고, 실시간 알림을 발송하는 기능을 완성했습니다.

### 주요 구현 사항

**1. Kafka Consumer 구현 (2개)**
- `OrderCreatedConsumer`: `order.created` 토픽 구독
  - 주문 생성 이벤트 수신 → Gemini AI로 출발 시한 계산 → Slack 알림 발송
  - 기존 REST API 로직 재사용 (`NotificationService.sendOrderNotificationFromEvent`)
- `DeliveryStatusChangedConsumer`: `delivery.status.changed` 토픽 구독
  - 배송 상태 변경 이벤트 수신 → Slack 알림 발송
  - 상태 변경 메시지 자동 생성 및 DB 저장

**2. 멱등성 보장**
- `event_id` 필드를 DB에 unique constraint로 저장
- `NotificationRepository.existsByEventId()` 체크로 중복 이벤트 처리 방지
- 중복 이벤트는 로그만 남기고 skip

**3. Kafka Configuration**
- `KafkaConsumerConfig`: 토픽별 별도 `KafkaListenerContainerFactory` 생성
  - `orderCreatedKafkaListenerContainerFactory`
  - `deliveryStatusChangedKafkaListenerContainerFactory`
- `ErrorHandlingDeserializer` + `JsonDeserializer` 조합으로 JSON 파싱 에러 처리
- `TopicProperties`: `@ConfigurationProperties`로 토픽 이름 관리

**4. Event DTOs (record pattern)**
- `OrderCreatedEvent`: eventId, occurredAt, order (15개 필드)
- `DeliveryStatusChangedEvent`: eventId, occurredAt, delivery (5개 필드)
- Nested records: OrderData, DeliveryData, RouteData, ReceiverData, HubManagerData

**5. DB Schema 수정**
- `MessageType` enum에 `DELIVERY_STATUS_UPDATE` 추가
- PostgreSQL CHECK constraint 업데이트:
  ```sql
  ALTER TABLE p_notifications DROP CONSTRAINT p_notifications_message_type_check;
  ALTER TABLE p_notifications ADD CONSTRAINT p_notifications_message_type_check
    CHECK (message_type IN ('ORDER_NOTIFICATION', 'DAILY_ROUTE', 'DELIVERY_STATUS_UPDATE', 'MANUAL'));
  ```

**6. 트랜잭션 설계**
- DB 저장 (트랜잭션 내부) → Slack 발송 (트랜잭션 외부)
- 외부 API 호출을 트랜잭션 밖으로 분리하여 롤백 시 데이터 일관성 보장

### 기술 스택
- Spring Kafka 3.2.2
- Apache Kafka 3.7.1 (Confluent Platform 7.5.0)
- PostgreSQL 17

## 🌐 Test Result

### 통합 테스트 결과 (test-kafka-consumer.sh)

**실행 환경**: Docker Compose (docker-compose-team.yml)

```bash
cd notification-service/scripts
bash test-kafka-consumer.sh
```

**테스트 시나리오 4개 (전체 통과)**

✅ **TEST 1**: order.created 이벤트 처리
- Kafka 메시지 발행 → Consumer 수신 → Gemini AI 호출 → Slack 발송 → DB 저장
- Event ID: `test-event-b7c207e2-ff5e-4e2b-bf21-9bd9ed3422fb`

✅ **TEST 2**: order.created 멱등성 검증
- 동일한 event_id로 재발행 → Consumer가 중복 감지하여 skip
- 로그: `⏭️ Event already processed (idempotency)`

✅ **TEST 3**: delivery.status.changed 이벤트 처리
- Kafka 메시지 발행 → Consumer 수신 → Slack 발송 → DB 저장
- Event ID: `test-delivery-event-898324c0-5e36-4d79-99bc-0701f44326b1`
- 상태 변경: `HUB_WAITING` → `HUB_MOVING`

✅ **TEST 4**: delivery.status.changed 멱등성 검증
- 동일한 event_id로 재발행 → Consumer가 중복 감지하여 skip

**테스트 로그 저장 위치**: `notification-service/test-results/kafka-test-20251111-215205.log`

### Slack 메시지 발송 확인

**Real Slack Integration** (채널: C09QY22AMEE)
- ✅ 주문 알림 메시지 발송 성공 (AI 계산된 출발 시한 포함)
- ✅ 배송 상태 업데이트 메시지 발송 성공

**배송 상태 변경 메시지 예시**:
```
🚚 *배송 상태 업데이트*

배송 ID: `74a57dc1-fa58-4d7c-a511-178c3556e43a`
주문 ID: `e516c633-1f3d-45dc-b5c9-abdcc10b9c02`
이전 상태: `HUB_WAITING`
현재 상태: `HUB_MOVING`

수령인: Test Hub Manager
```

### DB 검증

PostgreSQL 쿼리 결과:
```sql
SELECT message_id, message_type, event_id, status
FROM p_notifications
WHERE event_id LIKE 'test-%'
ORDER BY created_at DESC;
```

결과:
- ✅ 각 event_id당 1개의 레코드만 존재 (멱등성 보장)
- ✅ message_type = `DELIVERY_STATUS_UPDATE` 정상 저장
- ✅ status = `SENT` (Slack 발송 성공)

## 🔎 To Reviewer

### 1. 트랜잭션 범위 설계

**현재 구현** (`DeliveryStatusChangedConsumer.java:82`):
```java
@Transactional
private void sendSlackNotification(Notification notification, ...) {
    // Slack API 호출
}
```

**문제점**:
- `sendSlackNotification` 메서드가 `@Transactional`로 선언되어 있음
- Slack API 호출이 트랜잭션 내부에서 실행됨
- 롤백 시 Slack 메시지가 이미 전송된 상태로 남을 수 있음

**개선 방향** (Issue #76 리스크 개선에서 처리 예정):
- `@Transactional` 제거하여 외부 API 호출을 트랜잭션 외부로 분리
- DB 저장 → 커밋 → Slack 발송 순서 보장

### 2. DB CHECK 제약조건 수정

**변경 내용**:
- `p_notifications` 테이블의 `message_type` CHECK constraint에 `DELIVERY_STATUS_UPDATE` 추가
- Docker 실행 중 PostgreSQL에 직접 ALTER TABLE 실행

**리뷰 포인트**:
- 현재 수정 방식이 적절한지 확인 필요

### 3. Kafka Consumer Configuration

**토픽별 별도 ContainerFactory 생성**:
```java
@Bean
public ConcurrentKafkaListenerContainerFactory<String, OrderCreatedEvent>
    orderCreatedKafkaListenerContainerFactory() {
    // ...
}

@Bean
public ConcurrentKafkaListenerContainerFactory<String, DeliveryStatusChangedEvent>
    deliveryStatusChangedKafkaListenerContainerFactory() {
    // ...
}
```

**리뷰 포인트**:
- 토픽별 ContainerFactory 분리가 필요한지 vs 단일 Factory 공유
- 현재 방식의 장단점 의견 부탁드립니다

### 4. 멱등성 구현 방식

**현재 구현**:
- DB에 `event_id` unique constraint
- Consumer에서 `existsByEventId()` 체크

**리뷰 포인트**:
- 멱등성 구현이 충분한지
- 동시성 이슈 가능성 (race condition)
- `@Transactional` 레벨이나 DB isolation level 조정 필요 여부

### 5. 테스트 전략

**현재 테스트**:
- ✅ 통합 테스트 스크립트 (test-kafka-consumer.sh)
- ❌ 단위 테스트 (MockKafka 또는 EmbeddedKafka)

**리뷰 포인트**:
- 단위 테스트 추가 필요 여부
- 통합 테스트만으로 충분한지 의견 부탁드립니다

### 6. 향후 작업 (Issue #76 리스크 개선)

**리뷰 완료 후 진행 예정**:
- 트랜잭션 범위 리팩토링
- 통합 테스트 분리 (@EnabledIfEnvironmentVariable)
- NotificationService 단위 테스트 추가
- Entity 예외 타입 통일 (IllegalStateException → CustomException)