### PR TITLE
fix: 스웨거 테스트 코드 설정 및 오류 코드 설정 수정

### DIFF
--- a/notification-service/src/main/java/com/oneforlogis/notification/presentation/advice/NotificationExceptionHandler.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/presentation/advice/NotificationExceptionHandler.java
@@ -1,8 +1,58 @@
 package com.oneforlogis.notification.presentation.advice;
 
+import com.oneforlogis.common.api.ApiResponse;
+import feign.FeignException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class NotificationExceptionHandler {
-    // TODO: Implement exception handlers
+
+    /**
+     * FeignClient 호출 실패 처리
+     * - user-service 등 다른 서비스 호출 실패 시 적절한 HTTP 상태 코드 반환
+     */
+    @ExceptionHandler(FeignException.class)
+    protected ResponseEntity<ApiResponse<Void>> handleFeignException(FeignException e) {
+        int status = e.status();
+        String message = extractFeignErrorMessage(e);
+
+        log.error("[FeignException] status={}, message={}", status, message);
+
+        // FeignException의 status를 그대로 사용
+        HttpStatus httpStatus = HttpStatus.valueOf(status);
+        ApiResponse<Void> response = new ApiResponse<>(false, status, message, null);
+
+        return new ResponseEntity<>(response, httpStatus);
+    }
+
+    /**
+     * FeignException에서 의미 있는 에러 메시지 추출
+     */
+    private String extractFeignErrorMessage(FeignException e) {
+        int status = e.status();
+
+        // HTTP 상태 코드별로 사용자 친화적인 메시지 반환
+        return switch (status) {
+            case 400 -> "외부 서비스 요청 형식이 올바르지 않습니다. (user-service 연동 실패)";
+            case 401 -> "외부 서비스 인증에 실패했습니다. (user-service 연동 실패)";
+            case 403 -> "요청한 리소스에 접근할 수 없습니다. (user-service 연동 실패)";
+            case 404 -> "요청한 리소스를 찾을 수 없습니다. (user-service 연동 실패)";
+            case 408 -> "외부 서비스 요청 시간이 초과되었습니다. (user-service 연동 실패)";
+            case 500 -> "외부 서비스에서 오류가 발생했습니다. (user-service 연동 실패)";
+            case 503 -> "외부 서비스를 일시적으로 사용할 수 없습니다. (user-service 연동 실패)";
+            default -> {
+                if (status >= 400 && status < 500) {
+                    yield "외부 서비스 요청 처리에 실패했습니다. (user-service 연동 실패)";
+                } else if (status >= 500) {
+                    yield "외부 서비스에서 오류가 발생했습니다. (user-service 연동 실패)";
+                }
+                yield "외부 서비스 연동 중 오류가 발생했습니다.";
+            }
+        };
+    }
 }

--- a/notification-service/src/main/java/com/oneforlogis/notification/presentation/request/DeliveryStatusNotificationRequest.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/presentation/request/DeliveryStatusNotificationRequest.java
@@ -24,7 +24,7 @@ public record DeliveryStatusNotificationRequest(
         @NotBlank(message = "현재 배송 상태는 필수입니다.")
         String currentStatus,
 
-        @Schema(description = "수신자 Slack ID (허브 관리자 또는 배송 담당자)", example = "U01234ABCDE")
+        @Schema(description = "수신자 Slack ID (허브 관리자 또는 배송 담당자)", example = "C09QY22AMEE")
         @NotBlank(message = "수신자 Slack ID는 필수입니다.")
         String recipientSlackId,
 

--- a/notification-service/src/main/java/com/oneforlogis/notification/presentation/request/ManualNotificationRequest.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/presentation/request/ManualNotificationRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "수동 메시지 발송 요청 DTO - 인증된 사용자가 직접 Slack 메시지 발송")
 public record ManualNotificationRequest(
-        @Schema(description = "수신자 Slack ID", example = "U01234ABCDE")
+        @Schema(description = "수신자 Slack ID", example = "C09QY22AMEE")
         @NotBlank(message = "수신자 Slack ID는 필수입니다.")
         String recipientSlackId,
 

--- a/notification-service/src/main/java/com/oneforlogis/notification/presentation/request/OrderNotificationRequest.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/presentation/request/OrderNotificationRequest.java
@@ -52,7 +52,7 @@ public record OrderNotificationRequest(
         @NotBlank(message = "배송 담당자 정보는 필수입니다.")
         String deliveryPersonInfo,
 
-        @Schema(description = "발송 허브 관리자 Slack ID", example = "U01234ABCDE")
+        @Schema(description = "발송 허브 관리자 Slack ID", example = "C09QY22AMEE")
         @NotBlank(message = "수신자 Slack ID는 필수입니다.")
         String recipientSlackId,
 

--- a/notification-service/src/main/java/com/oneforlogis/notification/presentation/response/NotificationResponse.java
+++ b/notification-service/src/main/java/com/oneforlogis/notification/presentation/response/NotificationResponse.java
@@ -19,13 +19,13 @@ public record NotificationResponse(
         @Schema(description = "발신자 사용자명 (USER 타입만)", example = "user1")
         String senderUsername,
 
-        @Schema(description = "발신자 Slack ID (USER 타입만)", example = "U01234ABCDE")
+        @Schema(description = "발신자 Slack ID (USER 타입만)", example = "C09QY22AMEE")
         String senderSlackId,
 
         @Schema(description = "발신자 이름 (USER 타입만)", example = "김발신")
         String senderName,
 
-        @Schema(description = "수신자 Slack ID", example = "U98765ZYXWV")
+        @Schema(description = "수신자 Slack ID", example = "C09QY22AMEE")
         String recipientSlackId,
 
         @Schema(description = "수신자 이름", example = "이수신")

--- a/notification-service/src/test/java/com/oneforlogis/notification/presentation/controller/NotificationControllerTest.java
+++ b/notification-service/src/test/java/com/oneforlogis/notification/presentation/controller/NotificationControllerTest.java
@@ -85,7 +85,7 @@ class NotificationControllerTest {
                 "부산 허브",
                 "부산시 해운대구",
                 "배송담당: 홍길동",
-                "U123456",
+                "C09QY22AMEE",
                 "부산허브 관리자"
         );
 
@@ -109,7 +109,7 @@ class NotificationControllerTest {
     void sendManualNotification_Success() throws Exception {
         // Given
         ManualNotificationRequest request = new ManualNotificationRequest(
-                "U789012",
+                "C09QY22AMEE",
                 "수신자 이름",
                 "테스트 메시지입니다."
         );
@@ -118,7 +118,7 @@ class NotificationControllerTest {
                 .userId(1L)
                 .username("testuser")
                 .name("테스트 사용자")
-                .slackId("U123456")
+                .slackId("C09QY22AMEE")
                 .role(Role.HUB_MANAGER)
                 .build();
 
@@ -127,9 +127,9 @@ class NotificationControllerTest {
                 UUID.randomUUID(),
                 SenderType.USER,
                 "testuser",
-                "U123456",
+                "C09QY22AMEE",
                 "테스트 사용자",
-                "U789012",
+                "C09QY22AMEE",
                 "수신자 이름",
                 "테스트 메시지입니다.",
                 MessageType.MANUAL,
@@ -148,7 +148,7 @@ class NotificationControllerTest {
         when(notificationService.sendManualNotification(
                 any(ManualNotificationRequest.class),
                 eq("testuser"),
-                eq("U123456"),
+                eq("C09QY22AMEE"),
                 eq("테스트 사용자")
         )).thenReturn(response);
 
@@ -173,7 +173,7 @@ class NotificationControllerTest {
                 orderId,
                 "HUB_WAITING",
                 "HUB_MOVING",
-                "U123456",
+                "C09QY22AMEE",
                 "배송담당자"
         );
 
@@ -184,7 +184,7 @@ class NotificationControllerTest {
                 null,
                 null,
                 null,
-                "U123456",
+                "C09QY22AMEE",
                 "배송담당자",
                 "🚚 *배송 상태 업데이트*\n\n배송 ID: `" + deliveryId + "`\n주문 ID: `" + orderId + "`\n이전 상태: `HUB_WAITING`\n현재 상태: `HUB_MOVING`\n\n수령인: 배송담당자\n",
                 MessageType.DELIVERY_STATUS_UPDATE,
@@ -221,7 +221,7 @@ class NotificationControllerTest {
                 UUID.randomUUID(),
                 "HUB_WAITING",
                 "HUB_MOVING",
-                "U123456",
+                "C09QY22AMEE",
                 "배송담당자"
         );
 
@@ -367,7 +367,7 @@ class NotificationControllerTest {
 
         when(notificationService.searchNotifications(
                 eq("testuser"),
-                eq("U123456"),
+                eq("C09QY22AMEE"),
                 eq(MessageType.MANUAL),
                 eq(MessageStatus.SENT),
                 anyInt(), anyInt(), anyString(), anyBoolean()))
@@ -376,7 +376,7 @@ class NotificationControllerTest {
         // When & Then
         mockMvc.perform(get("/api/v1/notifications/search")
                         .param("senderUsername", "testuser")
-                        .param("recipientSlackId", "U123456")
+                        .param("recipientSlackId", "C09QY22AMEE")
                         .param("messageType", "MANUAL")
                         .param("status", "SENT")
                         .param("page", "0")
@@ -424,7 +424,7 @@ class NotificationControllerTest {
     void sendManualNotification_Forbidden() throws Exception {
         // Given
         ManualNotificationRequest request = new ManualNotificationRequest(
-                "U789012",
+                "C09QY22AMEE",
                 "수신자",
                 "테스트"
         );
@@ -456,7 +456,7 @@ class NotificationControllerTest {
                 null,
                 null,
                 null,
-                "U123456",
+                "C09QY22AMEE",
                 "수신자",
                 "테스트 메시지",
                 MessageType.ORDER_NOTIFICATION,


### PR DESCRIPTION
## Issue Number
> closed #109

## 📝 Description
### 1. Slack ID 통일 (C09QY22AMEE)
- 테스트 코드와 DTO의 Slack ID를 실제 사용 중인 채널 ID로 통일
- 12개 테스트 케이스 + 5개 DTO 예시 변경
- Swagger 문서와 실제 테스트 간 일관성 확보

### 2. FeignException 처리 추가
- NotificationExceptionHandler에 FeignException 처리 로직 구현
- HTTP 상태 코드 불일치 해결 (500 → 403)
- 7가지 주요 HTTP 에러 + default 처리
- 사용자 친화적인 한글 에러 메시지 제공

## 🌐 Test Result
- docker 실행 환경에서 notification-service 모두 통과

## 🔎 To Reviewer
### **✅ User-Service 연동 해결 (최종 솔루션)**
**위치**: UserServiceClient, NotificationController

**초기 문제**:
```
GET /api/v1/users/username/{username} - 엔드포인트 미구현
```

- notification-service의 `UserServiceClient.getUserByUsername()` 호출 실패
- 수동 메시지 API 테스트 불가 (403 Forbidden)

**최종 솔루션**: ✅ **기존 마이페이지 API 활용**

```java
// UserServiceClient.java
@GetMapping("/api/v1/users/me")
ApiResponse<UserResponse> getMyInfo(@RequestHeader("X-User-Id") UUID userId);

// NotificationController.java
ApiResponse<UserResponse> userApiResponse = userServiceClient.getMyInfo(userPrincipal.id());
```
